### PR TITLE
Update client "ready" call example

### DIFF
--- a/src/reference/interactive/protocol/protocol.rst
+++ b/src/reference/interactive/protocol/protocol.rst
@@ -418,8 +418,7 @@ The client should call the ``ready`` method after initialization is complete to 
     "method": "ready",
     "params": {
       "isReady": true
-    },
-    "discard": true
+    }
   }
 
 - A successful reply:


### PR DESCRIPTION
Update client "ready" call example to indicate not to discard it. With the example as is, a client would not receive a "ready" reply from the Interactive service.