### PR TITLE
Minor adjustments and corrections post-rebrand

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Beam Interactive, Inc.
+Copyright (c) Microsoft Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # Developers [![Join the chat at https://gitter.im/WatchBeam/developers](https://badges.gitter.im/WatchBeam/developers.svg)](https://gitter.im/WatchBeam/developers?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-Project used to generate contents of the [Developer Documentation](https://dev.beam.pro).
+Project used to generate contents of the [Developer Documentation](https://dev.mixer.com).
 
 ## Requirements
 - [Maven](https://maven.apache.org/)

--- a/src/css/_footer.less
+++ b/src/css/_footer.less
@@ -25,6 +25,10 @@
         display: block;
         margin-top: 40px;
         max-width: 100%;
+
+        img {
+            width: 100%;
+        }
     }
 
     .copyright {

--- a/src/index.pug
+++ b/src/index.pug
@@ -35,7 +35,7 @@ block content
                     p Create an Interactive #[br] Integration
                 .col-md-3.col-sm-6.col-xs-12: a(href='/tutorials/rest.html')
                     .slide-features-img
-                        img(src='/img/icon/computer-chip.svg' alt='RestAPI Docs')
+                        img(src='/img/icon/computer-chip.svg' alt='REST API Docs')
                     p Talk to our #[br] RESTful API
                 .col-md-3.col-sm-6.col-xs-12: a(href='/tutorials/constellation.html')
                     .slide-features-img
@@ -53,7 +53,7 @@ block content
                 p.
                     If you find bugs, things that need improvement,
                     or want to submit your own client library here,
-                    just open an issue on our Github repo.
+                    just open an issue on our GitHub repo.
                 div(style='flex:1')
                 .slide-grab-devbot
                     img(src='/img/DevBot.png' alt='DevBot says hi!')
@@ -101,12 +101,12 @@ block content
                 .col-md-3.col-sm-6.col-xs-12: a(href='https://forums.mixer.com/category/10/developer-discussion' target='_blank')
                     .slide-features-img
                         img(src='/img/icon/chat-double-bubble-1.svg' alt='Go to our Dev Forums' target='_blank')
-                    p Checkout our #[br] Developer Forums
-                .col-md-3.col-sm-6.col-xs-12: a(href='https://twitter.com/Mixer' target='_blank')
+                    p Check out our #[br] Developer Forums
+                .col-md-3.col-sm-6.col-xs-12: a(href='https://twitter.com/WatchMixer' target='_blank')
                     .slide-features-img
                         img(src='/img/icon/logo-twitter-bird.svg' alt='Find us on Twitter' target='_blank')
                     p Find us on #[br] Twitter
                 .col-md-3.col-sm-6.col-xs-12: a(href='https://github.com/mixer' target='_blank')
                     .slide-features-img
-                        img(src='/img/icon/logo-github.svg' alt='View our Projects on Github')
-                    p View our Projects #[br] on Github
+                        img(src='/img/icon/logo-github.svg' alt='View our Projects on GitHub')
+                    p View our Projects #[br] on GitHub

--- a/src/layout.pug
+++ b/src/layout.pug
@@ -26,7 +26,8 @@ mixin navbar
                     li: a(href='/reference/constellation/index.html') Constellation
                     li: a(href='/reference/oauth/index.html') OAuth
 
-            li: a(href='https://mixer.com/lab' target='_blank') Lab &amp; Apps
+            li: a(href='https://mixer.com/lab/oauth' target='_blank') OAuth Apps
+            li: a(href='https://mixer.com/i/studio' target='_blank') Interactive Studio
 
 include ./mixins.pug
 
@@ -66,24 +67,25 @@ html
                         h3 Mixer
                         ul
                             li: a(href='https://mixer.com' target='_blank') Home
-                            li: a(href='https://mixer.com/browse/streamers' target='_blank') Browse
-                            li: a(href='https://mixer.com/about/features' target='_blank') About
+                            li: a(href='https://mixer.com/browse/all' target='_blank') Browse
+                            li: a(href='https://mixer.com/about/story' target='_blank') About
                             li: a(href='https://mixer.com/contact' target='_blank') Contact Us
 
                     .col-lg-2.col-md-3.col-xs-6
                         h3 Social
                         ul
-                            li: a(href='https://twitter.com/Mixer' target='_blank') Twitter
-                            li: a(href='https://github.com/mixer' target='_blank') Github
+                            li: a(href='https://twitter.com/WatchMixer' target='_blank') Twitter
+                            li: a(href='https://github.com/mixer' target='_blank') GitHub
                             li: a(href='https://gitter.im/Mixer/developers' target='_blank') Gitter.im
-                            li: a(href='https://facebook.com/watchbeam' target='_blank') Facebook
+                            li: a(href='https://facebook.com/WatchMixer' target='_blank') Facebook
 
                     .col-lg-2.col-md-3.col-xs-6
                         h3 Network
                         ul
                             li: a(href='https://mixer.com' target='_blank') mixer.com
-                            li: a(href='http://forums.mixer.com/' target='_blank') Mixer Forums
+                            li: a(href='https://forums.mixer.com/' target='_blank') Mixer Forums
                             li: a(href='https://blog.mixer.com/' target='_blank') Blog
+                            li: a(href='https://feedback.mixer.com/forums/382521-lazers-and-shiny-things/category/174978-developer-ecosystem' target='_blank') Feedback
 
                     .col-lg-2.col-md-3.col-xs-6
                         h3 Legal

--- a/src/reference/chat/data.json
+++ b/src/reference/chat/data.json
@@ -1,7 +1,7 @@
 {
   "methods": {
     "auth": {
-      "description": "Authenticate to join as an active user in a specified channel. Arguments are `channelId`,`userId`,`key`. The channelId is the id of the channel you wish to join. The userId is the id of the user you are joining as. The key is retrieved from a request to our Rest Api as explained in the [Connection](#chat__connection) section. \n\r You can connect anonymously by just supplying the `channelId` as an argument. If you do this you will not be able to send messages or participate in chat. This can be useful for creating chat overlays.",
+      "description": "Authenticate as an active user in a specified channel. Arguments are `channelId`, `userId`, `key`. The channelId is the id of the channel you wish to join. The userId is the id of the user you are joining as. The key is retrieved from a request to our REST API as explained in the [Connection](#chat__connection) section. \n\r You can connect anonymously by just supplying the `channelId` as an argument. If you do this you will not be able to send messages or participate in chat. This can be useful for creating chat overlays.",
       "examples": [
         {
           "description": "Authenticating as a User successfully.",
@@ -79,7 +79,7 @@
       ]
     },
     "msg": {
-      "description": "Send a chat message to the server, the server will reply with data identical to a [ChatMessage](#chat__events__) event.",
+      "description": "Send a chat message to the server. The server will reply with data identical to a [ChatMessage](#chat__events__) event.",
       "example": {
         "request": {
           "type": "method",
@@ -157,7 +157,7 @@
       }
     },
     "vote:choose": {
-      "description": "Casts a vote for the current poll, `arguments` is the vote option index.",
+      "description": "Cast a vote in the current poll. `arguments` is the vote option's index.",
       "example": {
         "request": {
           "type": "method",
@@ -176,7 +176,7 @@
       }
     },
     "vote:start": {
-      "description": "Starts a poll in the channel, requires appropriate permissions.",
+      "description": "Start a poll in the channel. This requires the `poll_start` permission.",
       "example": {
         "request": {
           "type": "method",
@@ -200,7 +200,7 @@
       }
     },
     "timeout": {
-      "description": "Times a User out, they cannot send messages until the duration is over.",
+      "description": "Time a User out. They cannot send messages until the duration is over.",
       "example": {
         "request": {
           "type": "method",
@@ -220,7 +220,7 @@
       }
     },
     "purge": {
-      "description": "Purges a user's message from that chat but does not time them out.",
+      "description": "Purge a user's messages from that chat but does not time them out.",
       "example": {
         "request": {
           "type": "method",
@@ -238,7 +238,7 @@
       }
     },
     "deleteMessage": {
-      "description": "Deletes a message from chat by. First argument must be the message ID you want to delete.",
+      "description": "Delete a message from chat. First argument must be the message ID you want to delete.",
       "example": {
         "request": {
           "type": "method",
@@ -257,7 +257,7 @@
       }
     },
     "clearMessages": {
-      "description": "Clears all chat messages in the channel. (If you have the `clear_messages` permission)",
+      "description": "Clear all chat messages in the channel. This requires the `clear_messages` permission.",
       "example": {
         "request": {
           "type": "method",
@@ -330,7 +330,7 @@
       }
     },
     "ping": {
-      "description": "A ping method, used in environments where websocket implementations do not natively support pings.",
+      "description": "A ping method. This is used in environments where websocket implementations do not natively support pings.",
       "example": {
         "request": {
           "type": "method",
@@ -346,7 +346,7 @@
       }
     },
     "attachEmotes": {
-      "description": "Enables an enhancement to the `ChatMessage` event. Will populate the `meta` property of the event with a hash containing the emoticon text mapped to the base64 PNG representation.",
+      "description": "Enable an enhancement to the `ChatMessage` event. This will populate the `meta` property of the event with a hash containing the emoticon text mapped to the base64 PNG representation.",
       "examples": [
         {
           "description": "Tells the chat server that you want emotes to be attached to chat messages.",
@@ -419,7 +419,7 @@
       }
     },
     "ChatMessage": {
-      "description": "Sent by the server when a client sends a message. It contains multiple message components, including plain `text`, `emoticons`, and `tags`. The `meta` property of a message contains various attributes which defined additional details about where the message comes from.",
+      "description": "Sent by the server when a client sends a message. It contains multiple message components, including plain `text`, `emoticons`, and `tags`. The `meta` property of a message contains various attributes which define additional details about where the message comes from.",
       "examples": [
         {
           "title": "Regular Message",
@@ -572,7 +572,7 @@
       ]
     },
     "UserJoin": {
-      "description": "Sent when a user joins the chat, not emitted for unauthenticated users.",
+      "description": "Sent when a user joins the chat. This is not emitted for unauthenticated users.",
       "example": {
         "username": "USERNAME",
         "roles": [
@@ -582,14 +582,14 @@
       }
     },
     "UserLeave": {
-      "description": "Sent when a user leaves the chat, not emitted for unauthenticated users.",
+      "description": "Sent when a user leaves the chat. This is not emitted for unauthenticated users.",
       "example": {
         "username": "USERNAME",
         "id": 12345
       }
     },
     "PollStart": {
-      "description": "Initially sent when a new poll is started. Then over the course of a poll it is re-sent with information about the polls progress.",
+      "description": "Initially sent when a new poll is started. Then, over the course of a poll, it is re-sent with information about the poll's progress.",
       "example": {
         "q": "How's the weather?",
         "answers": [
@@ -613,7 +613,7 @@
       }
     },
     "PollEnd": {
-      "description": "Sent when a poll ended.",
+      "description": "Sent when a poll has ended.",
       "example": {
         "q": "How's the weather?",
         "answers": [

--- a/src/reference/chat/index.pug
+++ b/src/reference/chat/index.pug
@@ -20,17 +20,17 @@ block reference
         and received in standard JSON.
     h2(id='chat__connection') Connection
     p.
-        To connect to the chat server, you first need to retrieve some connection details from our Rest API. You can do this by calling the #[a(href='/rest.html#chats__chat__get') GET /chats/{channelId}] REST endpoint where #[code channelId] is the channel id of the channel you wish to join and chat in.
+        To connect to the chat server, you first need to retrieve some connection details from our REST API. You can do this by calling the #[a(href='/rest.html#chats__chat__get') GET /chats/{channelId}] REST endpoint where #[code channelId] is the channel id of the channel you wish to join and chat in.
     include ../../tutorials/channelid.pug
     p.
-        If you are authenticated when you make the request you will recieve an #[code authkey] in the response for authentication purposes. You may join chat and read messages without being authenticated,
+        If you are authenticated when you make the request, you will receive an #[code authkey] in the response for authentication purposes. You may join chat and read messages without being authenticated,
         but you will not be able to participate in chat.
     p.
         This is what a typical response from the
         #[a(href='/rest.html#chats__chat__get') GET /chats/{channelId}] endpoint looks like:
     +highlightFile('http', 'reference/chat/chatEndpoint.json')
     p.
-        Once you have the details, you'll need to use them to connect to a chat server. The reponse's #[code endpoint] array contains a list of chat servers. You should choose one randomly to connect to. If you lose connection to this address, you should re-connect to a different server (you can be chosen randomly or via a round-robin strategy of your choosing).
+        Once you have the details, you'll need to use them to connect to a chat server. The response's #[code endpoint] array contains a list of chat servers. You should choose one randomly to connect to. If you lose connection to this address, you should reconnect to a different server (you can choose randomly or use a round-robin strategy of your choosing).
     p.
         After connecting to a server you must call the #[a(href='#chat__methods__auth') auth] method.
 
@@ -167,5 +167,5 @@ block reference
             ol
                 li The #[strong channel id] of the channel you wish to chat in encoded as a #[strong Number].
                 li The #[strong user id] of the user you wish to chat as encoded as a #[strong Number].
-                li An #[strong authentication key] retrieved from #[a(href='/rest.html#chats__chat__get') GET /chats/{channelId}]. Where #[strong channelId] matches the first argument. It should be encoded as a #[strong String].
+                li An #[strong authentication key] retrieved from #[a(href='/rest.html#chats__chat__get') GET /chats/{channelId}], where #[strong channelId] matches the first argument. It should be encoded as a #[strong String].
     include ../../snippets/help.pug

--- a/src/reference/interactive1/index.pug
+++ b/src/reference/interactive1/index.pug
@@ -16,7 +16,7 @@ block menu
 block reference
     h1(id='interactive') Interactive
     .alert.alert-warning
-        p These reference docs are for Interactive 1. Checkout our #[a(href='/reference/interactive/index.html') Interactive 2 docs].
+        p These reference docs are for Interactive 1. Check out our #[a(href='/reference/interactive/index.html') Interactive 2 docs].
 
     p Mixer Interactive is a new way to let viewers directly control the environment around streamers using a visual interface. It works with any game and is built into the Mixer platform. Interactive games can be played with streamers or fully autonomously.
 

--- a/src/reference/interactive1/protocol.pug
+++ b/src/reference/interactive1/protocol.pug
@@ -2,7 +2,7 @@ include ../../mixins.pug
 h1#interactive__connection Connection
 p.
     To make a connection you first need to have an authenticated session with our
-    #[a(href='#') Rest API]. Once you have one you make a #[code GET] request to
+    #[a(href='#') REST API]. Once you have one you make a #[code GET] request to
     #[code /interactive/{channel}/robot] where #[code channel] is the channel id of the
     channel you wish to connect to.
 include ../../tutorials/channelid.pug
@@ -66,7 +66,7 @@ table.table
         td Progress Update
 h2(id='interactive__protocol') Specification
 p.
-    The protocol buffer specification for beam interactive lists packet types and
+    The protocol buffer specification for Mixer interactive lists packet types and
     structures within those packets in more detail:
 
 +highlightFile('protobuf','./reference/interactive1/proto/tetris.proto')

--- a/src/reference/oauth/index.pug
+++ b/src/reference/oauth/index.pug
@@ -23,10 +23,8 @@ block reference
     .page-header
         h2#quick_details Quick details:
         p.
-            You can register your OAuth application on our
-            #[a(href='https://mixer.com/lab' target='_blank') Developer Lab].
-            After getting a token there, you can use provide these endpoints to your OAuth
-            client library to dig in:
+            You can register your OAuth application on your #[a(href='https://mixer.com/lab/oauth' target='_blank') OAuth Clients] page.
+            After getting a token there, you can use provide these endpoints to your OAuth client library to dig in:
 
         ul
             li
@@ -56,7 +54,7 @@ block reference
 
     h2#introduction Introduction
     p.
-        If you want to act as another user in chat, access a users' private resources as part
+        If you want to act as another user in chat, access a user's private resources as part
         of your app, or just want to use Mixer credentials to authenticate your users,
         it's best to use OAuth so the users' credentials don't need to be stored on your servers.
 
@@ -64,15 +62,14 @@ block reference
         OAuth is a system that replaces traditional user/password combos with app-specific tokens.
         Your app can request a set of tokens for a certain user with a specific set of permissions.
         This way your app only gets access to what it needs and all other details will stay hidden.
-        It's a win-win scenario for both your app's functionality, and our user's privacy.
+        It's a win-win scenario for both your app's functionality, and our users' privacy.
 
     p To start using OAuth create an application as described below.
 
     h2#registering Registering Your Application
     p.
-        To create an application head over to the
-        #[a(href='https://mixer.com/lab' target='_blank') Developer Lab] and select the OAuth Clients tab.
-        Once there, click the big blue plus button and it'll open the creation form.
+        To create an application, head over to your #[a(href='https://mixer.com/lab/oauth' target='_blank') OAuth Clients] page.
+        Once there, click the blue "Create New Client" button and it'll open the creation form.
 
     p.
         On this page you'll need to enter some basic details about your application,

--- a/src/tutorials/channelid.pug
+++ b/src/tutorials/channelid.pug
@@ -2,4 +2,4 @@ p.
     You can find your channel id by
     going to
     #[a(href='https://mixer.com/api/v1/channels/{username}?fields=id') https://mixer.com/api/v1/channels/username?fields=id]
-    in your browser. Replacing username with your Mixer username.
+    in your browser, replacing #[code username] with your Mixer username.

--- a/src/tutorials/chatbot.pug
+++ b/src/tutorials/chatbot.pug
@@ -128,7 +128,7 @@ block tutorialContent
                 and an acknowledgement of our auth.
     h2 Want More Info?
     p.
-        If you'd like more information on our Chat system, checkout the #[a(href='/reference/chat/index.html') reference guide].
+        If you'd like more information on our Chat system, check out the #[a(href='/reference/chat/index.html') reference guide].
     include ../snippets/help.pug
 block tutorialMenu
     li: a(href='#guide') Guide

--- a/src/tutorials/constellation.pug
+++ b/src/tutorials/constellation.pug
@@ -9,9 +9,9 @@ block tutorialTitle
 block tutorialContent
     h2#intro Introduction
     p.
-        Constellation is our daemon responsible for stateful aspects of Mixer. One of it's features is Live Loading. Live Loading let's you recieve realtime updates of models and resources as they change on beam.
+        Constellation is our daemon responsible for stateful aspects of Mixer. One of its features is Live Loading. Live Loading let's you receive realtime updates of models and resources as they change on Mixer.
     p.
-        In this tutorial we're going to connect to Constellation and subscribe to Live Loading updates of your channel. If your viewer number or channel title change you'll recieve an update within your code that you can respond to.
+        In this tutorial we're going to connect to Constellation and subscribe to Live Loading updates of your channel. If your viewer count or channel title changes, you'll receive an update within your code that you can respond to.
 
     h2#code Writing the Code
     p Select a language below.
@@ -40,7 +40,7 @@ block tutorialContent
 
             +highlightFile('javascript','./tutorials/code/node/constellation/2.js')
 
-            p To recieve Live Loading events you need to subscribe to them. We'll just need #[code channel:{id}:update]. For a full list of events check our #[a(href='/reference/constellation/index.html#events_live_events') Constellation reference guide]. You subscribe to events within Carina by using the #[code subscribe] method.
+            p To receive Live Loading events you need to subscribe to them. We'll just need #[code channel:{id}:update]. For a full list of events check our #[a(href='/reference/constellation/index.html#events_live_events') Constellation reference guide]. You subscribe to events within Carina by using the #[code subscribe] method.
 
             +highlightFile('javascript','./tutorials/code/node/constellation/3.js')
 
@@ -51,7 +51,7 @@ block tutorialContent
             p.
                 That's it! Save the file as 'constellation.js' and run it with #[code node constellation.js] from your terminal. Try updating your channel details.
             p.
-                For example if you update your channel title from the Player to be 'test'. You'll get an object from the event that looks like this:
+                For example, if you update your channel title to 'test', you'll get an object from the event that looks like this:
             +highlightFile('javascript','./tutorials/code/node/constellation/example_data.js')
             p.
                 Try updating your channel description, age rating or selected game for more examples.
@@ -60,14 +60,14 @@ block tutorialContent
 
             +highlightFile('javascript','./tutorials/code/node/constellation/5.js')
 
-            p Carina also works with TypeScript and your Browser. For more information on it checkout its #[a(href='https://github.com/watchbeam/carina') Github page].
+            p Carina also works with TypeScript and your Browser. For more information, check out its #[a(href='https://github.com/mixer/carina') GitHub page].
     h2 Further Ideas
     ul
         li Why not combine Constellation with our #[a(href='/tutorials/rest.html') REST API] and make something super cool?
         li Use some of the other #[a(href='/reference/constellation/index.html#events_live_events') Constellation events] to get events about your stream.
     h2 Want More Info?
     p.
-        If you'd like more information on Constellation system, checkout the #[a(href='/reference/constellation/index.html') reference guide].
+        If you'd like more information on Constellation system, check out the #[a(href='/reference/constellation/index.html') reference guide].
     include ../snippets/help.pug
 block tutorialMenu
     li: a(href='#intro') Introduction

--- a/src/tutorials/interactive.pug
+++ b/src/tutorials/interactive.pug
@@ -13,7 +13,7 @@ block tutorialContent
     h2#intro Introduction
     .alert.alert-warning
         p.
-            These tutorials are for #[a(href='/reference/interactive1/index.html') Interactive 1], Interactive 2 tutorials are coming soon! While you wait, checkout our #[a(href='/reference/interactive/index.html') Interactive 2 reference docs].
+            These tutorials are for #[a(href='/reference/interactive1/index.html') Interactive 1], Interactive 2 tutorials are coming soon! While you wait, check out our #[a(href='/reference/interactive/index.html') Interactive 2 reference docs].
     p.
         Our interactive platform communicates using #[a(href='https://developers.google.com/protocol-buffers/' target='_blank') Google's Protocol Buffer]
         specification over a standard secure websocket protocol (wss) connection. Viewers' inputs from the site are sent to Mixer's aggregator
@@ -141,7 +141,7 @@ block tutorialContent
 
     h2 Want More Info?
     p.
-        If you'd like more information on our Interactive system, checkout the #[a(href='/reference/interactive/index.html') reference guide].
+        If you'd like more information on our Interactive system, check out the #[a(href='/reference/interactive/index.html') reference guide].
     include ../snippets/help.pug
 block tutorialMenu
     li: a(href='#intro') Introduction

--- a/src/tutorials/rest.pug
+++ b/src/tutorials/rest.pug
@@ -124,5 +124,5 @@ block tutorialContent
 
     h2 Want More Info?
     p.
-        If you'd like more information on our Rest API, checkout the #[a(href='/rest.html') rest reference docs].
+        If you'd like more information on our REST API, check out the #[a(href='/rest.html') REST API reference docs].
     include ../snippets/help.pug


### PR DESCRIPTION
* Changed Twitter and Facebook links from /Mixer to /WatchMixer.
* Replace the v1 "Interactive Lab" button in the navigation bar with links to "Interactive Studio" and "OAuth Apps".
    * Definitely open to feedback on this one in particular. I think it makes sense to put direct links to the new studio in the navbar, particularly because the legacy lab is already linked to from the v2 studio, in the v1 docs, and on the main site's navbar.
* Replace any links for OAuth with a direct link to /lab/oauth.
* Fix broken About link in the footer.
* Fix Mixer logo overflowing outside of the footer.
* https'ify forums link.
* Add link to feedback in the footer.
* Update license copyright.
* Fix a few instances where we still said Beam, not Mixer.
* Made a quick pass over some of the pages and fixed any spelling/grammar nits.