### PR TITLE
Added: Moderator object to the PurgeMessage event.

### DIFF
--- a/src/reference/chat/data.json
+++ b/src/reference/chat/data.json
@@ -658,11 +658,20 @@
       }
     },
     "PurgeMessage": {
-      "description": "Sent when a user's messages are purged.",
+      "description": "Sent when a user's messages are purged. Note: The moderator object is only set when a user is purged from in chat. The ban event triggers a purge but the object is not defined.",
       "example": {
         "type": "event",
         "event": "PurgeMessage",
         "data": {
+          "moderator": {
+            "user_name": "USERNAME",
+            "user_id": 12345,
+            "user_roles": [
+              "Mod",
+              "User"
+            ],
+            "user_level": 12
+          },
           "user_id": 12345
         }
       }

--- a/src/reference/chat/data.json
+++ b/src/reference/chat/data.json
@@ -681,7 +681,17 @@
       "example": {
         "type": "event",
         "event": "ClearMessages",
-        "data": {}
+        "data": {
+          "clearer": {
+            "user_name": "USERNAME",
+            "user_id": 12345,
+            "user_roles": [
+              "Mod",
+              "User"
+            ],
+            "user_level": 12
+          }
+        }
       }
     },
     "UserUpdate": {


### PR DESCRIPTION
- Also made a note about the object not being defined when the event is trigged from a ban and not an actual moderator timing a user out.