### PR TITLE
Add documentation for approval_prompt=force

### DIFF
--- a/src/reference/oauth/index.pug
+++ b/src/reference/oauth/index.pug
@@ -18,6 +18,7 @@ block menu
                 li: a(href='#hosts') Hosts
                 li: a(href='#using_oauth') Using OAuth
                 li: a(href='#shortcode') Short Code Authentication
+                li: a(href='#reauthorization') Reauthorizing an Application
                 li: a(href='#oauth_scopes') OAuth Scopes
 block reference
     .page-header
@@ -46,7 +47,7 @@ block reference
             tr
                 td #[a(href='https://tools.ietf.org/html/rfc6749#section-1.5') Refresh Token]
                 td 1 Year
-                td This is single use, if used a new refresh token is issued with the new access token.
+                td This is single use. If used, a new refresh token is issued with the new access token.
             tr
                 td Implicit Token
                 td 1 Year
@@ -127,6 +128,10 @@ block reference
             Your application polls #[a(href='/rest.html#oauth_shortcode_check__handle__get' target='_blank') /oauth/shortcode/check/{handle}] with the value of #[code handle] to check if the code has been used.
         li.
             If the user entered the code and accepted your application, you will receive an OAuth authorization code, #[code code], which you will then pass to the #[a(href='/rest.html#oauth_token_post' target='_blank') /oauth/token] endpoint through the #[a(href='https://tools.ietf.org/html/rfc6749#section-4.1.3' target='_blank') standard authorization_code process].
+
+    h3#reauthorization Reauthorizing an application
+    p.
+        If a user is sent to the Authorize endpoint and they have already granted the permissions to the application before, Mixer will automatically skip the approval page for convenience, so the user does not have to approve again. In some cases this might be undesirable, and you can force the user to reapprove the application every time by passing #[code approval_prompt=force] in the Authorize endpoint's URL.
 
     h2#oauth_scopes OAuth Scopes
     p.


### PR DESCRIPTION
Added a sentence to the OAuth reference page to clarify we allow you to set `approval_prompt=force` to prevent automatic reauthorization.