### PR TITLE
feat(constellation): add documentation for events

### DIFF
--- a/src/reference/constellation/events.json
+++ b/src/reference/constellation/events.json
@@ -9,94 +9,111 @@
     "channel:{id}:followed": {
         "description": "Sent when a user follows or unfollows a channel.",
         "payload": {
-            "followed": {
-                "type": "boolean",
-                "description": "Whether the user just followed the channel (`true` if this was a follow and `false` if this was an unfollow)."
-            },
-            "user": {
-                "type": "User",
-                "description": "The user who followed the channel."
+            "type": "object",
+            "properties": {
+                "followed": {
+                    "type": "boolean",
+                    "description": "Whether the user just followed the channel (`true` if this was a follow and `false` if this was an unfollow)."
+                },
+                "user": {
+                    "type": "User",
+                    "description": "The user who followed the channel."
+                }
             }
         }
     },
     "channel:{id}:hosted": {
         "description": "Sent when another user hosts the channel with the provided `id`. Note that this event is not subject to the spam prevention that the chat message is.",
         "payload": {
-            "hosterId": {
-                "type": "uint",
-                "description": "The user ID of the user who hosted the channel."
-            },
-            "hoster": {
-                "type": "User",
-                "description": "The user object of the user who hosted the channel."
+            "type": "object",
+            "properties": {
+                "hosterId": {
+                    "type": "uint",
+                    "description": "The user ID of the user who hosted the channel."
+                },
+                "hoster": {
+                    "type": "User",
+                    "description": "The user object of the user who hosted the channel."
+                }
             }
         }
     },
     "channel:{id}:unhosted": {
         "description": "Sent when another user finishes hosting the channel with the provided `id`. Note that this event is not subject to the spam prevention that the chat message is.",
         "payload": {
-            "hosterId": {
-                "type": "uint",
-                "description": "The user ID of the user who hosted the channel."
-            },
-            "hoster": {
-                "type": "User",
-                "description": "The user who hosted the channel."
+            "type": "object",
+            "properties": {
+                "hosterId": {
+                    "type": "uint",
+                    "description": "The user ID of the user who hosted the channel."
+                },
+                "hoster": {
+                    "type": "User",
+                    "description": "The user who hosted the channel."
+                }
             }
         }
     },
     "channel:{id}:status": {
-        "description": "Subscribes to the online status of a channel. You'll get events sent down named `chat:{id}:StartStreaming` and `chat:{id}:StopStreaming`.",
-        "payload": {}
+        "description": "Subscribes to the online status of a channel. You'll get events sent down named `chat:{id}:StartStreaming` and `chat:{id}:StopStreaming`."
     },
     "channel:{id}:subscribed": {
         "description": "Sent when a user subscribes to the channel.",
         "payload": {
-            "user": {
-                "type": "User",
-                "description": "The user who just subscribed to the channel."
+            "type": "object",
+            "properties": {
+                "user": {
+                    "type": "User",
+                    "description": "The user who just subscribed to the channel."
+                }
             }
         }
     },
     "channel:{id}:resubscribed": {
         "description": "Sent when an automatic resubscription to a channel happens.",
         "payload": {
-            "user": {
-                "type": "User",
-                "description": "The user who just subscribed to the channel."
-            },
-            "since": {
-                "type": "IsoDate",
-                "description": "The date for when the user first subscribed, from the start of the recurring billing period."
-            },
-            "until": {
-                "type": "IsoDate",
-                "description": "The date for when the subscription expires."
-            },
-            "totalMonths": {
-                "type": "uint",
-                "description": "The number of months the user has been subscribed since the beginning of time."
+            "type": "object",
+            "properties": {
+                "user": {
+                    "type": "User",
+                    "description": "The user who just subscribed to the channel."
+                },
+                "since": {
+                    "type": "IsoDate",
+                    "description": "The date for when the user first subscribed, from the start of the recurring billing period."
+                },
+                "until": {
+                    "type": "IsoDate",
+                    "description": "The date for when the subscription expires."
+                },
+                "totalMonths": {
+                    "type": "uint",
+                    "description": "The number of months the user has been subscribed since the beginning of time."
+                }
             }
         }
     },
     "channel:{id}:resubShared": {
         "description": "Sent when a user who has recently resubscribed to the channel chooses to 'share' their resubscription, by clicking the 'Share' button within the site chat. This event is preferred to the `channel:{id}:resubscribed` event if your integration reacts with some form of celebration, but you should be aware that this event will not fire at all for a resubscription if the user does not choose to share it. The body is identical to that of the `channel:{id}:resubscribed` event.",
         "payload": {
-            "user": {
-                "type": "User",
-                "description": "The user who just subscribed to the channel."
-            },
-            "since": {
-                "type": "IsoDate",
-                "description": "The date for when the user first subscribed, from the start of the recurring billing period."
-            },
-            "until": {
-                "type": "IsoDate",
-                "description": "The date for when the subscription expires."
-            },
-            "totalMonths": {
-                "type": "uint",
-                "description": "The number of months the user has been subscribed since the beginning of time."
+            "type": "object",
+            "properties": {
+                "user": {
+                    "type": "User",
+                    "description": "The user who just subscribed to the channel."
+                },
+                "since": {
+                    "type": "IsoDate",
+                    "description": "The date for when the user first subscribed, from the start of the recurring billing period."
+                },
+                "until": {
+                    "type": "IsoDate",
+                    "description": "The date for when the subscription expires."
+                },
+                "totalMonths": {
+                    "type": "uint",
+                    "description": "The number of months the user has been subscribed since the beginning of time."
+                }
             }
         }
     },
@@ -166,13 +183,16 @@
     "user:{id}:followed": {
         "description": "Sent when a user follows or unfollows a channel.",
         "payload": {
-            "followed": {
-                "type": "boolean",
-                "description": "Whether the user just followed the channel (`true` if this was a follow and `false` if this was an unfollow)."
-            },
-            "channel": {
-                "type": "Channel",
-                "description": "The channel that the user just followed."
+            "type": "object",
+            "properties": {
+                "followed": {
+                    "type": "boolean",
+                    "description": "Whether the user just followed the channel (`true` if this was a follow and `false` if this was an unfollow)."
+                },
+                "channel": {
+                    "type": "Channel",
+                    "description": "The channel that the user just followed."
+                }
             }
         }
     },
@@ -186,30 +206,36 @@
     "user:{id}:subscribed": {
         "description": "Sent when the user subscribes to another channel.",
         "payload": {
-            "channel": {
-                "type": "uint",
-                "description": "The ID of the channel the user subscribed to."
+            "type": "object",
+            "properties": {
+                "channel": {
+                    "type": "uint",
+                    "description": "The ID of the channel the user subscribed to."
+                }
             }
         }
     },
     "user:{id}:resubscribed": {
         "description": "Sent when an automatic resubscription to a channel happens.",
         "payload": {
-            "channel": {
-                "type": "uint",
-                "description": "The ID of the channel the user subscribed to."
-            },
-            "since": {
-                "type": "IsoDate",
-                "description": "The date for when the user first subscribed, from the start of the recurring billing period."
-            },
-            "until": {
-                "type": "IsoDate",
-                "description": "The date for when the subscription expires."
-            },
-            "totalMonths": {
-                "type": "uint",
-                "description": "The number of months the user has been subscribed since the beginning of time."
+            "type": "object",
+            "properties": {
+                "channel": {
+                    "type": "uint",
+                    "description": "The ID of the channel the user subscribed to."
+                },
+                "since": {
+                    "type": "IsoDate",
+                    "description": "The date for when the user first subscribed, from the start of the recurring billing period."
+                },
+                "until": {
+                    "type": "IsoDate",
+                    "description": "The date for when the subscription expires."
+                },
+                "totalMonths": {
+                    "type": "uint",
+                    "description": "The number of months the user has been subscribed since the beginning of time."
+                }
             }
         }
     },

--- a/src/reference/constellation/events.json
+++ b/src/reference/constellation/events.json
@@ -1,9 +1,12 @@
 {
     "⁠⁠⁠⁠announcement:announce": {
-        "description": "Sent when there is a site-wide announcement. The message property of the body contains the announcement text. Other fields affect how the announcement is displayed on mixer.com",
+        "description": "Sent when there is a site-wide announcement. The message property of the body contains the announcement text. Other fields affect how the announcement is displayed on mixer.com.",
         "payload": {
             "type": "Announcement",
             "description": "The site-wide announcement that has been sent."
+        },
+        "example": {
+            "message": "This is an announcement message."
         }
     },
     "channel:{id}:followed": {
@@ -17,9 +20,13 @@
                 },
                 "user": {
                     "type": "User",
-                    "description": "The user who followed the channel."
+                    "description": "The user who followed the channel. This also includes the channel object as `channel`."
                 }
             }
+        },
+        "example": {
+            "user": { "level": 5, "social": {}, "id": 696, "username": "HypeBot", "verified": true, "experience": 72, "sparks": 1620, "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg", "bio": "", "primaryTeam": null, "createdAt": "2015-02-19T17:43:07.000Z", "updatedAt": "2017-05-25T16:26:14.000Z", "deletedAt": null, "channel": { "featured": false, "id": 588, "userId": 696, "token": "HypeBot", "online": false, "featureLevel": 0, "partnered": false, "transcodingProfileId": 1, "suspended": false, "name": "HypeBot's Channel", "audience": "teen", "viewersTotal": 100, "viewersCurrent": 0, "numFollowers": 1000, "description": "<p>Hi! I'm HypeBot. Nice to meet you!</p>\n", "typeId": null, "interactive": false, "interactiveGameId": null, "ftl": 0, "hasVod": false, "languageId": null, "coverId": null, "thumbnailId": null, "badgeId": null, "bannerUrl": null, "hosteeId": null, "hasTranscodes": true, "vodsEnabled": true, "costreamId": null, "createdAt": "2015-04-09T07:37:51.000Z", "updatedAt": "2017-07-11T19:49:26.000Z", "deletedAt": null } },
+            "following": true
         }
     },
     "channel:{id}:hosted": {
@@ -29,13 +36,17 @@
             "properties": {
                 "hosterId": {
                     "type": "uint",
-                    "description": "The user ID of the user who hosted the channel."
+                    "description": "The channel ID who just hosted the channel."
                 },
                 "hoster": {
-                    "type": "User",
-                    "description": "The user object of the user who hosted the channel."
+                    "type": "Channel",
+                    "description": "The channel object who just hosted the channel."
                 }
             }
+        },
+        "example": {
+            "hosterId": 588,
+            "hoster": { "featured": false, "id": 588, "userId": 696, "token": "HypeBot", "online": false, "featureLevel": 0, "partnered": false, "transcodingProfileId": 1, "suspended": false, "name": "HypeBot's Channel", "audience": "teen", "viewersTotal": 100, "viewersCurrent": 0, "numFollowers": 1000, "description": "<p>Hi! I'm HypeBot. Nice to meet you!</p>\n", "typeId": null, "interactive": false, "interactiveGameId": null, "ftl": 0, "hasVod": false, "languageId": null, "coverId": null, "thumbnailId": null, "badgeId": null, "bannerUrl": null, "hosteeId": null, "hasTranscodes": true, "vodsEnabled": true, "costreamId": null, "createdAt": "2015-04-09T07:37:51.000Z", "updatedAt": "2017-07-11T19:49:26.000Z", "deletedAt": null }
         }
     },
     "channel:{id}:unhosted": {
@@ -45,13 +56,17 @@
             "properties": {
                 "hosterId": {
                     "type": "uint",
-                    "description": "The user ID of the user who hosted the channel."
+                    "description": "The ID of the user who hosted the channel."
                 },
                 "hoster": {
                     "type": "User",
                     "description": "The user who hosted the channel."
                 }
             }
+        },
+        "example": {
+            "hosterId": 588,
+            "hoster": { "featured": false, "id": 588, "userId": 696, "token": "HypeBot", "online": false, "featureLevel": 0, "partnered": false, "transcodingProfileId": 1, "suspended": false, "name": "HypeBot's Channel", "audience": "teen", "viewersTotal": 100, "viewersCurrent": 0, "numFollowers": 1000, "description": "<p>Hi! I'm HypeBot. Nice to meet you!</p>\n", "typeId": null, "interactive": false, "interactiveGameId": null, "ftl": 0, "hasVod": false, "languageId": null, "coverId": null, "thumbnailId": null, "badgeId": null, "bannerUrl": null, "hosteeId": null, "hasTranscodes": true, "vodsEnabled": true, "costreamId": null, "createdAt": "2015-04-09T07:37:51.000Z", "updatedAt": "2017-07-11T19:49:26.000Z", "deletedAt": null }
         }
     },
     "channel:{id}:status": {
@@ -67,6 +82,9 @@
                     "description": "The user who just subscribed to the channel."
                 }
             }
+        },
+        "example": {
+            "user": { "level": 5, "social": {}, "id": 696, "username": "HypeBot", "verified": true, "experience": 72, "sparks": 1620, "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg", "bio": "", "primaryTeam": null, "createdAt": "2015-02-19T17:43:07.000Z", "updatedAt": "2017-05-25T16:26:14.000Z", "deletedAt": null }
         }
     },
     "channel:{id}:resubscribed": {
@@ -91,6 +109,12 @@
                     "description": "The number of months the user has been subscribed since the beginning of time."
                 }
             }
+        },
+        "example": {
+            "user": { "level": 5, "social": {}, "id": 696, "username": "HypeBot", "verified": true, "experience": 72, "sparks": 1620, "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg", "bio": "", "primaryTeam": null, "createdAt": "2015-02-19T17:43:07.000Z", "updatedAt": "2017-05-25T16:26:14.000Z", "deletedAt": null },
+            "since": "2017-09-25T11:00:00.000Z",
+            "until": "2017-12-25T11:00:00.000Z",
+            "totalMonths": 3
         }
     },
     "channel:{id}:resubShared": {
@@ -115,6 +139,12 @@
                     "description": "The number of months the user has been subscribed since the beginning of time."
                 }
             }
+        },
+        "example": {
+            "user": { "level": 5, "social": {}, "id": 696, "username": "HypeBot", "verified": true, "experience": 72, "sparks": 1620, "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg", "bio": "", "primaryTeam": null, "createdAt": "2015-02-19T17:43:07.000Z", "updatedAt": "2017-05-25T16:26:14.000Z", "deletedAt": null },
+            "since": "2017-09-25T11:00:00.000Z",
+            "until": "2017-12-25T11:00:00.000Z",
+            "totalMonths": 3
         }
     },
     "channel:{id}:update": {
@@ -129,27 +159,38 @@
         "payload": {
             "type": "Costream",
             "description": "The full costream model after the costream has been changed."
-        }
+        },
+        "example": { "channels": [{ "id": 588, "token": "HypeBot", "userId": 696 }, { "id": 314, "token": "Mixer", "userId": 344 }], "capacity": 4, "layout": { "name": "grid", "order": [588, 314] }, "startedAt": "2017-07-13T16:44:15.684Z", "id": "2e86ca56-671f-4690-9fdb-1050d3c8e90d" }
     },
     "interactive:{id}:connect": {
         "description": "Sent when an interactive app connects to this channel.",
         "payload": {
             "type": "string",
             "description": "The address of the interactive server the application has connected to."
-        }
+        },
+        "example": "wss://interactive1-dal.mixer.com"
     },
     "interactive:{id}:disconnect": {
-        "description": "Sent when an interactive app disconnects from this channel",
+        "description": "Sent when an interactive app disconnects from this channel.",
         "payload": {
             "type": "string",
             "description": "The address of the interactive server the application has connected to."
-        }
+        },
+        "example": "wss://interactive1-dal.mixer.com"
     },
     "team:{id}:deleted": {
-        "description": "Sent when a team is deleted",
+        "description": "Sent when a team is deleted.",
         "payload": {
-            "type": "Team",
-            "description": "The team's record prior to deletion."
+            "type": "object",
+            "properties": {
+                "team": {
+                    "type": "Team",
+                    "description": "The team's record prior to deletion."
+                }
+            }
+        },
+        "example": {
+            "team": { "id": 7, "ownerId": 696, "token": "mixer", "name": "Mixer Team", "description": "<p>Mixer team streamers! </p>\n", "logoUrl": "https://uploads.mixer.com/team/logo/p0857ky5-7.png", "backgroundUrl": "https://uploads.mixer.com/team/background/7k5tsbnx-7.jpg", "totalViewersCurrent": 0, "createdAt": "2016-04-21T03:22:10.000Z", "updatedAt": "2017-06-05T16:38:10.000Z" }
         }
     },
     "team:{id}:memberAccepted": {
@@ -157,35 +198,40 @@
         "payload": {
             "type": "User",
             "description": "The user who accepted their invitation."
-        }
+        },
+        "example": { "level": 5, "social": {}, "id": 696, "username": "HypeBot", "verified": true, "experience": 72, "sparks": 1620, "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg", "bio": "", "primaryTeam": null, "createdAt": "2015-02-19T17:43:07.000Z", "updatedAt": "2017-05-25T16:26:14.000Z", "deletedAt": null }
     },
     "team:{id}:memberInvited": {
         "description": "Sent when a member is invited to a team.",
         "payload": {
             "type": "User",
             "description": "The user who was sent an invitation."
-        }
+        },
+        "example": { "level": 5, "social": {}, "id": 696, "username": "HypeBot", "verified": true, "experience": 72, "sparks": 1620, "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg", "bio": "", "primaryTeam": null, "createdAt": "2015-02-19T17:43:07.000Z", "updatedAt": "2017-05-25T16:26:14.000Z", "deletedAt": null }
     },
     "team:{id}:memberRemoved": {
         "description": "Sent when a team member leaves or invitee rejects their invite.",
         "payload": {
             "type": "User",
             "description": "The member who left the team."
-        }
+        },
+        "example": { "level": 5, "social": {}, "id": 696, "username": "HypeBot", "verified": true, "experience": 72, "sparks": 1620, "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg", "bio": "", "primaryTeam": null, "createdAt": "2015-02-19T17:43:07.000Z", "updatedAt": "2017-05-25T16:26:14.000Z", "deletedAt": null }
     },
     "team:{id}:ownerChanged": {
         "description": "Sent when a team's ownership changes.",
         "payload": {
             "type": "User",
             "description": "The new team owner."
-        }
+        },
+        "example": { "level": 5, "social": {}, "id": 696, "username": "HypeBot", "verified": true, "experience": 72, "sparks": 1620, "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg", "bio": "", "primaryTeam": null, "createdAt": "2015-02-19T17:43:07.000Z", "updatedAt": "2017-05-25T16:26:14.000Z", "deletedAt": null }
     },
     "user:{id}:achievement": {
         "description": "Sent when a user achievement earning is updated.",
         "payload": {
             "type": "AchievementEarning",
             "description": "The updated achievement."
-        }
+        },
+        "example": { "id": 70155, "earned": false, "progress": 0.2703, "createdAt": "2016-02-09T09:59:30.000Z", "updatedAt": "2017-07-13T16:39:27.000Z", "achievement": "followers-plat", "user": 696, "Achievement": { "slug": "followers-plat", "name": "Followers Platinum", "description": "Have at least ten thousand followers.", "sparks": 0 } }
     },
     "user:{id}:followed": {
         "description": "Sent when a user follows or unfollows a channel.",
@@ -201,14 +247,19 @@
                     "description": "The channel that the user just followed."
                 }
             }
+        },
+        "example": {
+            "following": true,
+            "channel": { "featured": false, "id": 588, "userId": 696, "token": "HypeBot", "online": false, "featureLevel": 0, "partnered": false, "transcodingProfileId": 1, "suspended": false, "name": "HypeBot's Channel", "audience": "teen", "viewersTotal": 100, "viewersCurrent": 0, "numFollowers": 1000, "description": "<p>Hi! I'm HypeBot. Nice to meet you!</p>\n", "typeId": null, "interactive": false, "interactiveGameId": null, "ftl": 0, "hasVod": false, "languageId": null, "coverId": null, "thumbnailId": null, "badgeId": null, "bannerUrl": null, "hosteeId": null, "hasTranscodes": true, "vodsEnabled": true, "costreamId": null, "createdAt": "2015-04-09T07:37:51.000Z", "updatedAt": "2017-07-11T19:49:26.000Z", "deletedAt": null }
         }
     },
     "user:{id}:notify": {
-        "description": "Sent when the user receives a new notification. Notifications of the same type will always follow the same structure.",
+        "description": "Sent when the user receives a new notification. Notifications of the same type will always follow the same structure. This event requires authentication.",
         "payload": {
             "type": "Notification",
             "description": "The new notification."
-        }
+        },
+        "example": { "id": "2e86ca56-671f-4690-9fdb-1050d3c8e90d", "userId": 696, "trigger":"", "type": "follow", "sentAt":"2017-07-13T16:21:09.294270964Z", "payload": { "type": "follow", "channelOwnerId": 588, "triggeringUser": { "level": 12, "social": {}, "id": 314, "username": "Mixer", "verified": true, "experience": 182251, "sparks": 204863, "avatarUrl": "https://uploads.beam.pro/avatar/yc9q94zf-344.jpg", "bio": null, "primaryTeam": null, "createdAt": "2016-07-20T17:26:50.000Z", "updatedAt": "2016-08-17T18:21:07.000Z", "deletedAt": null } } }
     },
     "user:{id}:subscribed": {
         "description": "Sent when the user subscribes to another channel.",
@@ -220,6 +271,9 @@
                     "description": "The ID of the channel the user subscribed to."
                 }
             }
+        },
+        "example": {
+            "channel": 588
         }
     },
     "user:{id}:resubscribed": {
@@ -244,6 +298,12 @@
                     "description": "The number of months the user has been subscribed since the beginning of time."
                 }
             }
+        },
+        "example": {
+            "channel": 588,
+            "since": "2017-09-25T11:00:00.000Z",
+            "until": "2017-12-25T11:00:00.000Z",
+            "totalMonths": 3
         }
     },
     "user:{id}:teamAccepted": {
@@ -251,21 +311,24 @@
         "payload": {
             "type": "Team",
             "description": "The team the user accepted the invitation for."
-        }
+        },
+        "example": { "id": 7, "ownerId": 696, "token": "mixer", "name": "Mixer Team", "description": "<p>Mixer team streamers! </p>\n", "logoUrl": "https://uploads.mixer.com/team/logo/p0857ky5-7.png", "backgroundUrl": "https://uploads.mixer.com/team/background/7k5tsbnx-7.jpg", "totalViewersCurrent": 0, "createdAt": "2016-04-21T03:22:10.000Z", "updatedAt": "2017-06-05T16:38:10.000Z" }
     },
     "user:{id}:teamInvited": {
         "description": "Sent when a user is invited to a team.",
         "payload": {
             "type": "Team",
-            "description": "The team the user was invited to."
-        }
+            "description": "The team the user was invited to. This includes the team owner's user object as `owner`."
+        },
+        "example": { "id": 7, "ownerId": 696, "token": "mixer", "name": "Mixer Team", "description": "<p>Mixer team streamers! </p>\n", "logoUrl": "https://uploads.mixer.com/team/logo/p0857ky5-7.png", "backgroundUrl": "https://uploads.mixer.com/team/background/7k5tsbnx-7.jpg", "totalViewersCurrent": 0, "createdAt": "2016-04-21T03:22:10.000Z", "updatedAt": "2017-06-05T16:38:10.000Z", "owner": { "level": 5, "social": {}, "id": 696, "username": "HypeBot", "verified": true, "experience": 72, "sparks": 1620, "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg", "bio": "", "primaryTeam": null, "createdAt": "2015-02-19T17:43:07.000Z", "updatedAt": "2017-05-25T16:26:14.000Z", "deletedAt": null } }
     },
     "user:{id}:teamRemoved": {
         "description": "Sent when a user leaves a team or rejects its invite.",
         "payload": {
             "type": "Team",
             "description": "The team the user left."
-        }
+        },
+        "example": { "id": 7, "ownerId": 696, "token": "mixer", "name": "Mixer Team", "description": "<p>Mixer team streamers! </p>\n", "logoUrl": "https://uploads.mixer.com/team/logo/p0857ky5-7.png", "backgroundUrl": "https://uploads.mixer.com/team/background/7k5tsbnx-7.jpg", "totalViewersCurrent": 0, "createdAt": "2016-04-21T03:22:10.000Z", "updatedAt": "2017-06-05T16:38:10.000Z" }
     },
     "user:{id}:update": {
         "description": "Sent when the user model is changed.",

--- a/src/reference/constellation/events.json
+++ b/src/reference/constellation/events.json
@@ -1,27 +1,244 @@
 {
-    "⁠⁠⁠⁠announcement:announce": "Sent when there is a site-wide announcement. The message property of the body contains the announcement text. Other fields affect how the announcement is displayed on mixer.com",
-    "channel:{id}:followed": "Sent when a user follows or unfollows a channel. The body will contain an attribute `following` - boolean set to true `true` if the user just followed the channel, `false` if they unfollowed, and user - the [User](/rest.html#User) who just followed the channel.",
-    "channel:{id}:hosted": "Sent when another user hosts the channel with the provided `id`. The body will contain the `hosterId`, a number, and `hoster`, the full [Channel](/rest.html#Channel) model who started hosting this channel. Note that this event is not subject to the spam prevention that the chat message is.",
-    "channel:{id}:unhosted": "Sent when another user finishes hosting the channel with the provided `id`. The body will contain the `hosterId`, a number, and `hoster`, the full [Channel](/rest.html#Channel) model who finished hosting this channel. Note that this event is not subject to the spam prevention that the chat message is.",
-    "channel:{id}:status": "Subscribes to the online status of a channel. You'll get events sent down named `chat:{id}:StartStreaming` and `chat:{id}:StopStreaming`.",
-    "channel:{id}:subscribed": "Sent when a user subscribes to the channel. The body will contain the [User](/rest.html#User) object who just subscribed to the channel.",
-    "channel:{id}:resubscribed": "Sent when an automatic resubscription to a channel happens. The body will contain the [User](/rest.html#User) object of the channel the user just resubscribed to. Additionally there are `since` and `until` properties. These are the dates for when the user first subscribed (from the start of recurring billing period) and when the subscription expires. Finally there's a `totalMonths` property, which is an integer indicating how many months the user has been subscribed since the beginning of time.",
-    "channel:{id}:resubShared": "Sent when a user who has recently resubscribed to the channel chooses to 'share' their resubscription, by clicking the 'Share' button within the site chat. This event is preferred to the `channel:{id}:resubscribed` event if your integration reacts with some form of celebration, but you should be aware that this event will not fire at all for a resubscription if the user does not choose to share it. The body is identical to that of the `channel:{id}:resubscribed` event.",
-    "channel:{id}:update": "You'll get an event sent down that matches the slug, containing changes on the [Channel model](/rest.html#Channel). The event may not necessarily include the entire channel resource. For example, when a channel goes online, an event with the key online going to true is sent.",
-    "interactive:{id}:connect": "Sent when an interactive app connects to this channel",
-    "interactive:{id}:disconnected": "Sent when an interactive app disconnects from this channel",
-    "team:{id}:deleted": "Sent when a [Team](/rest.html#Team) is deleted. The body will contain the team's old record.",
-    "team:{id}:memberAccepted": "Sent when an invitee accepts their team invitation. The body will contain the accepting user's record.",
-    "team:{id}:memberInvited": "Sent when a member is invited to a team. The body will contain the invited user's record.",
-    "team:{id}:memberRemoved": "Sent when a team member leaves or invitee rejects their invite. The body will contain the member's [User](/rest.html#User) record.",
-    "team:{id}:ownerChanged": "Sent when a team's ownership changes. The body will contain the new owner's [User](/rest.html#User) record.",
-    "user:{id}:achievement": "Sent when a user achievement earning is updated. The body is simply an [AchievementEarning](/rest.html#AchievementEarning) record as returned in the achievement user listing endpoint.",
-    "user:{id}:followed": "Sent when a user follows or unfollows a channel. The body will contain an attribute `following` - boolean set to true `true` if the user just followed the channel, `false` if they unfollowed, and user - the [User](/rest.html#User) who just followed the channel.",
-    "user:{id}:notify": "Sent when a new user [Notification](/rest.html#Notification) is created. Notifications of the same type will always follow the same structure.",
-    "user:{id}:subscribed": "Sent when the user subscribes to a channel. The body will contain the channel ID that they just subscribed to.",
-    "user:{id}:resubscribed": "Sent when an automatic resubscription to a channel happens. The body will contain the [Channel](/rest.html#Channel) id of the channel the user just resubscribed to. Additionally there are `since` and `until` properties. These are the dates for when the user first subscribed (from the start of recurring billing period) and when the subscription expires. Finally there's a `totalMonths` property, which is an integer indicating how many months the user has been subscribed since the beginning of time.",
-    "user:{id}:teamAccepted": "Sent when a user accepts their invite to a team. The body will contain the [Team](/rest.html#Team) record related to the event.",
-    "user:{id}:teamInvited": "Sent when a user is invited to a team. The body will contain the [Team](/rest.html#Team) record related to the event.",
-    "user:{id}:teamRemoved": "Sent when a user leaves a team or rejects its invite. The body will contain the [Team](/rest.html#Team) record related to the event.",
-    "user:{id}:update": "You'll get an event sent down that matches the slug, containing changes on the [User model](/rest.html#User). The event may not necessarily include the entire user resource."
+    "⁠⁠⁠⁠announcement:announce": {
+        "description": "Sent when there is a site-wide announcement. The message property of the body contains the announcement text. Other fields affect how the announcement is displayed on mixer.com",
+        "payload": {
+            "type": "Announcement",
+            "description": "The site-wide announcement that has been sent."
+        }
+    },
+    "channel:{id}:followed": {
+        "description": "Sent when a user follows or unfollows a channel.",
+        "payload": {
+            "followed": {
+                "type": "boolean",
+                "description": "Whether the user just followed the channel (`true` if this was a follow and `false` if this was an unfollow)."
+            },
+            "user": {
+                "type": "User",
+                "description": "The user who followed the channel."
+            }
+        }
+    },
+    "channel:{id}:hosted": {
+        "description": "Sent when another user hosts the channel with the provided `id`. Note that this event is not subject to the spam prevention that the chat message is.",
+        "payload": {
+            "hosterId": {
+                "type": "uint",
+                "description": "The user ID of the user who hosted the channel."
+            },
+            "hoster": {
+                "type": "User",
+                "description": "The user object of the user who hosted the channel."
+            }
+        }
+    },
+    "channel:{id}:unhosted": {
+        "description": "Sent when another user finishes hosting the channel with the provided `id`. Note that this event is not subject to the spam prevention that the chat message is.",
+        "payload": {
+            "hosterId": {
+                "type": "uint",
+                "description": "The user ID of the user who hosted the channel."
+            },
+            "hoster": {
+                "type": "User",
+                "description": "The user who hosted the channel."
+            }
+        }
+    },
+    "channel:{id}:status": {
+        "description": "Subscribes to the online status of a channel. You'll get events sent down named `chat:{id}:StartStreaming` and `chat:{id}:StopStreaming`.",
+        "payload": {}
+    },
+    "channel:{id}:subscribed": {
+        "description": "Sent when a user subscribes to the channel.",
+        "payload": {
+            "user": {
+                "type": "User",
+                "description": "The user who just subscribed to the channel."
+            }
+        }
+    },
+    "channel:{id}:resubscribed": {
+        "description": "Sent when an automatic resubscription to a channel happens.",
+        "payload": {
+            "user": {
+                "type": "User",
+                "description": "The user who just subscribed to the channel."
+            },
+            "since": {
+                "type": "IsoDate",
+                "description": "The date for when the user first subscribed, from the start of the recurring billing period."
+            },
+            "until": {
+                "type": "IsoDate",
+                "description": "The date for when the subscription expires."
+            },
+            "totalMonths": {
+                "type": "uint",
+                "description": "The number of months the user has been subscribed since the beginning of time."
+            }
+        }
+    },
+    "channel:{id}:resubShared": {
+        "description": "Sent when a user who has recently resubscribed to the channel chooses to 'share' their resubscription, by clicking the 'Share' button within the site chat. This event is preferred to the `channel:{id}:resubscribed` event if your integration reacts with some form of celebration, but you should be aware that this event will not fire at all for a resubscription if the user does not choose to share it. The body is identical to that of the `channel:{id}:resubscribed` event.",
+        "payload": {
+            "user": {
+                "type": "User",
+                "description": "The user who just subscribed to the channel."
+            },
+            "since": {
+                "type": "IsoDate",
+                "description": "The date for when the user first subscribed, from the start of the recurring billing period."
+            },
+            "until": {
+                "type": "IsoDate",
+                "description": "The date for when the subscription expires."
+            },
+            "totalMonths": {
+                "type": "uint",
+                "description": "The number of months the user has been subscribed since the beginning of time."
+            }
+        }
+    },
+    "channel:{id}:update": {
+        "description": "Sent when the channel model is changed.",
+        "payload": {
+            "type": "Channel",
+            "description": "Contains changes to the channel model. Please note this event may not necessarily include the entire channel resource. For example, when a channel goes online, an event with the key `online` going to `true` is sent."
+        }
+    },
+    "interactive:{id}:connect": {
+        "description": "Sent when an interactive app connects to this channel.",
+        "payload": {
+            "type": "string",
+            "description": "The address of the interactive server the application has connected to."
+        }
+    },
+    "interactive:{id}:disconnect": {
+        "description": "Sent when an interactive app disconnects from this channel",
+        "payload": {
+            "type": "string",
+            "description": "The address of the interactive server the application has connected to."
+        }
+    },
+    "team:{id}:deleted": {
+        "description": "Sent when a team is deleted",
+        "payload": {
+            "type": "Team",
+            "description": "The team's record prior to deletion."
+        }
+    },
+    "team:{id}:memberAccepted": {
+        "description": "Sent when an invitee accepts their team invitation.",
+        "payload": {
+            "type": "User",
+            "description": "The user who accepted their invitation."
+        }
+    },
+    "team:{id}:memberInvited": {
+        "description": "Sent when a member is invited to a team.",
+        "payload": {
+            "type": "User",
+            "description": "The user who was sent an invitation."
+        }
+    },
+    "team:{id}:memberRemoved": {
+        "description": "Sent when a team member leaves or invitee rejects their invite.",
+        "payload": {
+            "type": "User",
+            "description": "The member who left the team."
+        }
+    },
+    "team:{id}:ownerChanged": {
+        "description": "Sent when a team's ownership changes.",
+        "payload": {
+            "type": "User",
+            "description": "The new team owner."
+        }
+    },
+    "user:{id}:achievement": {
+        "description": "Sent when a user achievement earning is updated.",
+        "payload": {
+            "type": "AchievementEarning",
+            "description": "The updated achievement."
+        }
+    },
+    "user:{id}:followed": {
+        "description": "Sent when a user follows or unfollows a channel.",
+        "payload": {
+            "followed": {
+                "type": "boolean",
+                "description": "Whether the user just followed the channel (`true` if this was a follow and `false` if this was an unfollow)."
+            },
+            "channel": {
+                "type": "Channel",
+                "description": "The channel that the user just followed."
+            }
+        }
+    },
+    "user:{id}:notify": {
+        "description": "Sent when the user receives a new notification. Notifications of the same type will always follow the same structure.",
+        "payload": {
+            "type": "Notification",
+            "description": "The new notification."
+        }
+    },
+    "user:{id}:subscribed": {
+        "description": "Sent when the user subscribes to another channel.",
+        "payload": {
+            "channel": {
+                "type": "uint",
+                "description": "The ID of the channel the user subscribed to."
+            }
+        }
+    },
+    "user:{id}:resubscribed": {
+        "description": "Sent when an automatic resubscription to a channel happens.",
+        "payload": {
+            "channel": {
+                "type": "uint",
+                "description": "The ID of the channel the user subscribed to."
+            },
+            "since": {
+                "type": "IsoDate",
+                "description": "The date for when the user first subscribed, from the start of the recurring billing period."
+            },
+            "until": {
+                "type": "IsoDate",
+                "description": "The date for when the subscription expires."
+            },
+            "totalMonths": {
+                "type": "uint",
+                "description": "The number of months the user has been subscribed since the beginning of time."
+            }
+        }
+    },
+    "user:{id}:teamAccepted": {
+        "description": "Sent when a user accepts their invite to a team.",
+        "payload": {
+            "type": "Team",
+            "description": "The team the user accepted the invitation for."
+        }
+    },
+    "user:{id}:teamInvited": {
+        "description": "Sent when a user is invited to a team.",
+        "payload": {
+            "type": "Team",
+            "description": "The team the user was invited to."
+        }
+    },
+    "user:{id}:teamRemoved": {
+        "description": "Sent when a user leaves a team or rejects its invite.",
+        "payload": {
+            "type": "Team",
+            "description": "The team the user left."
+        }
+    },
+    "user:{id}:update": {
+        "description": "Sent when the user model is changed.",
+        "payload": {
+            "type": "User",
+            "description": "Contains changes to the user model. Please note this event may not necessarily include the entire user resource."
+        }
+    }
 }

--- a/src/reference/constellation/events.json
+++ b/src/reference/constellation/events.json
@@ -124,6 +124,13 @@
             "description": "Contains changes to the channel model. Please note this event may not necessarily include the entire channel resource. For example, when a channel goes online, an event with the key `online` going to `true` is sent."
         }
     },
+    "costream:{id}:update": {
+        "description": "Sent when a costream model is changed (e.g. when a streamer joins/leaves the costream, or when the costream's settings have been changed).",
+        "payload": {
+            "type": "Costream",
+            "description": "The full costream model after the costream has been changed."
+        }
+    },
     "interactive:{id}:connect": {
         "description": "Sent when an interactive app connects to this channel.",
         "payload": {

--- a/src/reference/constellation/events.json
+++ b/src/reference/constellation/events.json
@@ -25,7 +25,55 @@
             }
         },
         "example": {
-            "user": { "level": 5, "social": {}, "id": 696, "username": "HypeBot", "verified": true, "experience": 72, "sparks": 1620, "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg", "bio": "", "primaryTeam": null, "createdAt": "2015-02-19T17:43:07.000Z", "updatedAt": "2017-05-25T16:26:14.000Z", "deletedAt": null, "channel": { "featured": false, "id": 588, "userId": 696, "token": "HypeBot", "online": false, "featureLevel": 0, "partnered": false, "transcodingProfileId": 1, "suspended": false, "name": "HypeBot's Channel", "audience": "teen", "viewersTotal": 100, "viewersCurrent": 0, "numFollowers": 1000, "description": "<p>Hi! I'm HypeBot. Nice to meet you!</p>\n", "typeId": null, "interactive": false, "interactiveGameId": null, "ftl": 0, "hasVod": false, "languageId": null, "coverId": null, "thumbnailId": null, "badgeId": null, "bannerUrl": null, "hosteeId": null, "hasTranscodes": true, "vodsEnabled": true, "costreamId": null, "createdAt": "2015-04-09T07:37:51.000Z", "updatedAt": "2017-07-11T19:49:26.000Z", "deletedAt": null } },
+            "user": {
+                "level": 5,
+                "social": {},
+                "id": 696,
+                "username": "HypeBot",
+                "verified": true,
+                "experience": 72,
+                "sparks": 1620,
+                "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg",
+                "bio": "",
+                "primaryTeam": null,
+                "createdAt": "2015-02-19T17:43:07.000Z",
+                "updatedAt": "2017-05-25T16:26:14.000Z",
+                "deletedAt": null,
+                "channel": {
+                    "featured": false,
+                    "id": 588,
+                    "userId": 696,
+                    "token": "HypeBot",
+                    "online": false,
+                    "featureLevel": 0,
+                    "partnered": false,
+                    "transcodingProfileId": 1,
+                    "suspended": false,
+                    "name": "HypeBot's Channel",
+                    "audience": "teen",
+                    "viewersTotal": 100,
+                    "viewersCurrent": 0,
+                    "numFollowers": 1000,
+                    "description": "<p>Hi! I'm HypeBot. Nice to meet you!</p>\n",
+                    "typeId": null,
+                    "interactive": false,
+                    "interactiveGameId": null,
+                    "ftl": 0,
+                    "hasVod": false,
+                    "languageId": null,
+                    "coverId": null,
+                    "thumbnailId": null,
+                    "badgeId": null,
+                    "bannerUrl": null,
+                    "hosteeId": null,
+                    "hasTranscodes": true,
+                    "vodsEnabled": true,
+                    "costreamId": null,
+                    "createdAt": "2015-04-09T07:37:51.000Z",
+                    "updatedAt": "2017-07-11T19:49:26.000Z",
+                    "deletedAt": null
+                }
+            },
             "following": true
         }
     },
@@ -46,7 +94,40 @@
         },
         "example": {
             "hosterId": 588,
-            "hoster": { "featured": false, "id": 588, "userId": 696, "token": "HypeBot", "online": false, "featureLevel": 0, "partnered": false, "transcodingProfileId": 1, "suspended": false, "name": "HypeBot's Channel", "audience": "teen", "viewersTotal": 100, "viewersCurrent": 0, "numFollowers": 1000, "description": "<p>Hi! I'm HypeBot. Nice to meet you!</p>\n", "typeId": null, "interactive": false, "interactiveGameId": null, "ftl": 0, "hasVod": false, "languageId": null, "coverId": null, "thumbnailId": null, "badgeId": null, "bannerUrl": null, "hosteeId": null, "hasTranscodes": true, "vodsEnabled": true, "costreamId": null, "createdAt": "2015-04-09T07:37:51.000Z", "updatedAt": "2017-07-11T19:49:26.000Z", "deletedAt": null }
+            "hoster": {
+                "featured": false,
+                "id": 588,
+                "userId": 696,
+                "token": "HypeBot",
+                "online": false,
+                "featureLevel": 0,
+                "partnered": false,
+                "transcodingProfileId": 1,
+                "suspended": false,
+                "name": "HypeBot's Channel",
+                "audience": "teen",
+                "viewersTotal": 100,
+                "viewersCurrent": 0,
+                "numFollowers": 1000,
+                "description": "<p>Hi! I'm HypeBot. Nice to meet you!</p>\n",
+                "typeId": null,
+                "interactive": false,
+                "interactiveGameId": null,
+                "ftl": 0,
+                "hasVod": false,
+                "languageId": null,
+                "coverId": null,
+                "thumbnailId": null,
+                "badgeId": null,
+                "bannerUrl": null,
+                "hosteeId": null,
+                "hasTranscodes": true,
+                "vodsEnabled": true,
+                "costreamId": null,
+                "createdAt": "2015-04-09T07:37:51.000Z",
+                "updatedAt": "2017-07-11T19:49:26.000Z",
+                "deletedAt": null
+            }
         }
     },
     "channel:{id}:unhosted": {
@@ -66,7 +147,40 @@
         },
         "example": {
             "hosterId": 588,
-            "hoster": { "featured": false, "id": 588, "userId": 696, "token": "HypeBot", "online": false, "featureLevel": 0, "partnered": false, "transcodingProfileId": 1, "suspended": false, "name": "HypeBot's Channel", "audience": "teen", "viewersTotal": 100, "viewersCurrent": 0, "numFollowers": 1000, "description": "<p>Hi! I'm HypeBot. Nice to meet you!</p>\n", "typeId": null, "interactive": false, "interactiveGameId": null, "ftl": 0, "hasVod": false, "languageId": null, "coverId": null, "thumbnailId": null, "badgeId": null, "bannerUrl": null, "hosteeId": null, "hasTranscodes": true, "vodsEnabled": true, "costreamId": null, "createdAt": "2015-04-09T07:37:51.000Z", "updatedAt": "2017-07-11T19:49:26.000Z", "deletedAt": null }
+            "hoster": {
+                "featured": false,
+                "id": 588,
+                "userId": 696,
+                "token": "HypeBot",
+                "online": false,
+                "featureLevel": 0,
+                "partnered": false,
+                "transcodingProfileId": 1,
+                "suspended": false,
+                "name": "HypeBot's Channel",
+                "audience": "teen",
+                "viewersTotal": 100,
+                "viewersCurrent": 0,
+                "numFollowers": 1000,
+                "description": "<p>Hi! I'm HypeBot. Nice to meet you!</p>\n",
+                "typeId": null,
+                "interactive": false,
+                "interactiveGameId": null,
+                "ftl": 0,
+                "hasVod": false,
+                "languageId": null,
+                "coverId": null,
+                "thumbnailId": null,
+                "badgeId": null,
+                "bannerUrl": null,
+                "hosteeId": null,
+                "hasTranscodes": true,
+                "vodsEnabled": true,
+                "costreamId": null,
+                "createdAt": "2015-04-09T07:37:51.000Z",
+                "updatedAt": "2017-07-11T19:49:26.000Z",
+                "deletedAt": null
+            }
         }
     },
     "channel:{id}:status": {
@@ -84,7 +198,21 @@
             }
         },
         "example": {
-            "user": { "level": 5, "social": {}, "id": 696, "username": "HypeBot", "verified": true, "experience": 72, "sparks": 1620, "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg", "bio": "", "primaryTeam": null, "createdAt": "2015-02-19T17:43:07.000Z", "updatedAt": "2017-05-25T16:26:14.000Z", "deletedAt": null }
+            "user": {
+                "level": 5,
+                "social": {},
+                "id": 696,
+                "username": "HypeBot",
+                "verified": true,
+                "experience": 72,
+                "sparks": 1620,
+                "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg",
+                "bio": "",
+                "primaryTeam": null,
+                "createdAt": "2015-02-19T17:43:07.000Z",
+                "updatedAt": "2017-05-25T16:26:14.000Z",
+                "deletedAt": null
+            }
         }
     },
     "channel:{id}:resubscribed": {
@@ -111,7 +239,21 @@
             }
         },
         "example": {
-            "user": { "level": 5, "social": {}, "id": 696, "username": "HypeBot", "verified": true, "experience": 72, "sparks": 1620, "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg", "bio": "", "primaryTeam": null, "createdAt": "2015-02-19T17:43:07.000Z", "updatedAt": "2017-05-25T16:26:14.000Z", "deletedAt": null },
+            "user": {
+                "level": 5,
+                "social": {},
+                "id": 696,
+                "username": "HypeBot",
+                "verified": true,
+                "experience": 72,
+                "sparks": 1620,
+                "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg",
+                "bio": "",
+                "primaryTeam": null,
+                "createdAt": "2015-02-19T17:43:07.000Z",
+                "updatedAt": "2017-05-25T16:26:14.000Z",
+                "deletedAt": null
+            },
             "since": "2017-09-25T11:00:00.000Z",
             "until": "2017-12-25T11:00:00.000Z",
             "totalMonths": 3
@@ -141,7 +283,21 @@
             }
         },
         "example": {
-            "user": { "level": 5, "social": {}, "id": 696, "username": "HypeBot", "verified": true, "experience": 72, "sparks": 1620, "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg", "bio": "", "primaryTeam": null, "createdAt": "2015-02-19T17:43:07.000Z", "updatedAt": "2017-05-25T16:26:14.000Z", "deletedAt": null },
+            "user": {
+                "level": 5,
+                "social": {},
+                "id": 696,
+                "username": "HypeBot",
+                "verified": true,
+                "experience": 72,
+                "sparks": 1620,
+                "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg",
+                "bio": "",
+                "primaryTeam": null,
+                "createdAt": "2015-02-19T17:43:07.000Z",
+                "updatedAt": "2017-05-25T16:26:14.000Z",
+                "deletedAt": null
+            },
             "since": "2017-09-25T11:00:00.000Z",
             "until": "2017-12-25T11:00:00.000Z",
             "totalMonths": 3
@@ -160,7 +316,30 @@
             "type": "Costream",
             "description": "The full costream model after the costream has been changed."
         },
-        "example": { "channels": [{ "id": 588, "token": "HypeBot", "userId": 696 }, { "id": 314, "token": "Mixer", "userId": 344 }], "capacity": 4, "layout": { "name": "grid", "order": [588, 314] }, "startedAt": "2017-07-13T16:44:15.684Z", "id": "2e86ca56-671f-4690-9fdb-1050d3c8e90d" }
+        "example": {
+            "channels": [
+                {
+                    "id": 588,
+                    "token": "HypeBot",
+                    "userId": 696
+                },
+                {
+                    "id": 314,
+                    "token": "Mixer",
+                    "userId": 344
+                }
+            ],
+            "capacity": 4,
+            "layout": {
+                "name": "grid",
+                "order": [
+                    588,
+                    314
+                ]
+            },
+            "startedAt": "2017-07-13T16:44:15.684Z",
+            "id": "2e86ca56-671f-4690-9fdb-1050d3c8e90d"
+        }
     },
     "interactive:{id}:connect": {
         "description": "Sent when an interactive app connects to this channel.",
@@ -190,7 +369,18 @@
             }
         },
         "example": {
-            "team": { "id": 7, "ownerId": 696, "token": "mixer", "name": "Mixer Team", "description": "<p>Mixer team streamers! </p>\n", "logoUrl": "https://uploads.mixer.com/team/logo/p0857ky5-7.png", "backgroundUrl": "https://uploads.mixer.com/team/background/7k5tsbnx-7.jpg", "totalViewersCurrent": 0, "createdAt": "2016-04-21T03:22:10.000Z", "updatedAt": "2017-06-05T16:38:10.000Z" }
+            "team": {
+                "id": 7,
+                "ownerId": 696,
+                "token": "mixer",
+                "name": "Mixer Team",
+                "description": "<p>Mixer team streamers! </p>\n",
+                "logoUrl": "https://uploads.mixer.com/team/logo/p0857ky5-7.png",
+                "backgroundUrl": "https://uploads.mixer.com/team/background/7k5tsbnx-7.jpg",
+                "totalViewersCurrent": 0,
+                "createdAt": "2016-04-21T03:22:10.000Z",
+                "updatedAt": "2017-06-05T16:38:10.000Z"
+            }
         }
     },
     "team:{id}:memberAccepted": {
@@ -199,7 +389,21 @@
             "type": "User",
             "description": "The user who accepted their invitation."
         },
-        "example": { "level": 5, "social": {}, "id": 696, "username": "HypeBot", "verified": true, "experience": 72, "sparks": 1620, "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg", "bio": "", "primaryTeam": null, "createdAt": "2015-02-19T17:43:07.000Z", "updatedAt": "2017-05-25T16:26:14.000Z", "deletedAt": null }
+        "example": {
+            "level": 5,
+            "social": {},
+            "id": 696,
+            "username": "HypeBot",
+            "verified": true,
+            "experience": 72,
+            "sparks": 1620,
+            "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg",
+            "bio": "",
+            "primaryTeam": null,
+            "createdAt": "2015-02-19T17:43:07.000Z",
+            "updatedAt": "2017-05-25T16:26:14.000Z",
+            "deletedAt": null
+        }
     },
     "team:{id}:memberInvited": {
         "description": "Sent when a member is invited to a team.",
@@ -207,7 +411,21 @@
             "type": "User",
             "description": "The user who was sent an invitation."
         },
-        "example": { "level": 5, "social": {}, "id": 696, "username": "HypeBot", "verified": true, "experience": 72, "sparks": 1620, "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg", "bio": "", "primaryTeam": null, "createdAt": "2015-02-19T17:43:07.000Z", "updatedAt": "2017-05-25T16:26:14.000Z", "deletedAt": null }
+        "example": {
+            "level": 5,
+            "social": {},
+            "id": 696,
+            "username": "HypeBot",
+            "verified": true,
+            "experience": 72,
+            "sparks": 1620,
+            "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg",
+            "bio": "",
+            "primaryTeam": null,
+            "createdAt": "2015-02-19T17:43:07.000Z",
+            "updatedAt": "2017-05-25T16:26:14.000Z",
+            "deletedAt": null
+        }
     },
     "team:{id}:memberRemoved": {
         "description": "Sent when a team member leaves or invitee rejects their invite.",
@@ -215,7 +433,21 @@
             "type": "User",
             "description": "The member who left the team."
         },
-        "example": { "level": 5, "social": {}, "id": 696, "username": "HypeBot", "verified": true, "experience": 72, "sparks": 1620, "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg", "bio": "", "primaryTeam": null, "createdAt": "2015-02-19T17:43:07.000Z", "updatedAt": "2017-05-25T16:26:14.000Z", "deletedAt": null }
+        "example": {
+            "level": 5,
+            "social": {},
+            "id": 696,
+            "username": "HypeBot",
+            "verified": true,
+            "experience": 72,
+            "sparks": 1620,
+            "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg",
+            "bio": "",
+            "primaryTeam": null,
+            "createdAt": "2015-02-19T17:43:07.000Z",
+            "updatedAt": "2017-05-25T16:26:14.000Z",
+            "deletedAt": null
+        }
     },
     "team:{id}:ownerChanged": {
         "description": "Sent when a team's ownership changes.",
@@ -223,7 +455,21 @@
             "type": "User",
             "description": "The new team owner."
         },
-        "example": { "level": 5, "social": {}, "id": 696, "username": "HypeBot", "verified": true, "experience": 72, "sparks": 1620, "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg", "bio": "", "primaryTeam": null, "createdAt": "2015-02-19T17:43:07.000Z", "updatedAt": "2017-05-25T16:26:14.000Z", "deletedAt": null }
+        "example": {
+            "level": 5,
+            "social": {},
+            "id": 696,
+            "username": "HypeBot",
+            "verified": true,
+            "experience": 72,
+            "sparks": 1620,
+            "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg",
+            "bio": "",
+            "primaryTeam": null,
+            "createdAt": "2015-02-19T17:43:07.000Z",
+            "updatedAt": "2017-05-25T16:26:14.000Z",
+            "deletedAt": null
+        }
     },
     "user:{id}:achievement": {
         "description": "Sent when a user achievement earning is updated.",
@@ -231,7 +477,21 @@
             "type": "AchievementEarning",
             "description": "The updated achievement."
         },
-        "example": { "id": 70155, "earned": false, "progress": 0.2703, "createdAt": "2016-02-09T09:59:30.000Z", "updatedAt": "2017-07-13T16:39:27.000Z", "achievement": "followers-plat", "user": 696, "Achievement": { "slug": "followers-plat", "name": "Followers Platinum", "description": "Have at least ten thousand followers.", "sparks": 0 } }
+        "example": {
+            "id": 70155,
+            "earned": false,
+            "progress": 0.2703,
+            "createdAt": "2016-02-09T09:59:30.000Z",
+            "updatedAt": "2017-07-13T16:39:27.000Z",
+            "achievement": "followers-plat",
+            "user": 696,
+            "Achievement": {
+                "slug": "followers-plat",
+                "name": "Followers Platinum",
+                "description": "Have at least ten thousand followers.",
+                "sparks": 0
+            }
+        }
     },
     "user:{id}:followed": {
         "description": "Sent when a user follows or unfollows a channel.",
@@ -250,7 +510,40 @@
         },
         "example": {
             "following": true,
-            "channel": { "featured": false, "id": 588, "userId": 696, "token": "HypeBot", "online": false, "featureLevel": 0, "partnered": false, "transcodingProfileId": 1, "suspended": false, "name": "HypeBot's Channel", "audience": "teen", "viewersTotal": 100, "viewersCurrent": 0, "numFollowers": 1000, "description": "<p>Hi! I'm HypeBot. Nice to meet you!</p>\n", "typeId": null, "interactive": false, "interactiveGameId": null, "ftl": 0, "hasVod": false, "languageId": null, "coverId": null, "thumbnailId": null, "badgeId": null, "bannerUrl": null, "hosteeId": null, "hasTranscodes": true, "vodsEnabled": true, "costreamId": null, "createdAt": "2015-04-09T07:37:51.000Z", "updatedAt": "2017-07-11T19:49:26.000Z", "deletedAt": null }
+            "channel": {
+                "featured": false,
+                "id": 588,
+                "userId": 696,
+                "token": "HypeBot",
+                "online": false,
+                "featureLevel": 0,
+                "partnered": false,
+                "transcodingProfileId": 1,
+                "suspended": false,
+                "name": "HypeBot's Channel",
+                "audience": "teen",
+                "viewersTotal": 100,
+                "viewersCurrent": 0,
+                "numFollowers": 1000,
+                "description": "<p>Hi! I'm HypeBot. Nice to meet you!</p>\n",
+                "typeId": null,
+                "interactive": false,
+                "interactiveGameId": null,
+                "ftl": 0,
+                "hasVod": false,
+                "languageId": null,
+                "coverId": null,
+                "thumbnailId": null,
+                "badgeId": null,
+                "bannerUrl": null,
+                "hosteeId": null,
+                "hasTranscodes": true,
+                "vodsEnabled": true,
+                "costreamId": null,
+                "createdAt": "2015-04-09T07:37:51.000Z",
+                "updatedAt": "2017-07-11T19:49:26.000Z",
+                "deletedAt": null
+            }
         }
     },
     "user:{id}:notify": {
@@ -259,7 +552,32 @@
             "type": "Notification",
             "description": "The new notification."
         },
-        "example": { "id": "2e86ca56-671f-4690-9fdb-1050d3c8e90d", "userId": 696, "trigger":"", "type": "follow", "sentAt":"2017-07-13T16:21:09.294270964Z", "payload": { "type": "follow", "channelOwnerId": 588, "triggeringUser": { "level": 12, "social": {}, "id": 314, "username": "Mixer", "verified": true, "experience": 182251, "sparks": 204863, "avatarUrl": "https://uploads.beam.pro/avatar/yc9q94zf-344.jpg", "bio": null, "primaryTeam": null, "createdAt": "2016-07-20T17:26:50.000Z", "updatedAt": "2016-08-17T18:21:07.000Z", "deletedAt": null } } }
+        "example": {
+            "id": "2e86ca56-671f-4690-9fdb-1050d3c8e90d",
+            "userId": 696,
+            "trigger": "",
+            "type": "follow",
+            "sentAt": "2017-07-13T16:21:09.294270964Z",
+            "payload": {
+                "type": "follow",
+                "channelOwnerId": 588,
+                "triggeringUser": {
+                    "level": 12,
+                    "social": {},
+                    "id": 314,
+                    "username": "Mixer",
+                    "verified": true,
+                    "experience": 182251,
+                    "sparks": 204863,
+                    "avatarUrl": "https://uploads.beam.pro/avatar/yc9q94zf-344.jpg",
+                    "bio": null,
+                    "primaryTeam": null,
+                    "createdAt": "2016-07-20T17:26:50.000Z",
+                    "updatedAt": "2016-08-17T18:21:07.000Z",
+                    "deletedAt": null
+                }
+            }
+        }
     },
     "user:{id}:subscribed": {
         "description": "Sent when the user subscribes to another channel.",
@@ -312,7 +630,18 @@
             "type": "Team",
             "description": "The team the user accepted the invitation for."
         },
-        "example": { "id": 7, "ownerId": 696, "token": "mixer", "name": "Mixer Team", "description": "<p>Mixer team streamers! </p>\n", "logoUrl": "https://uploads.mixer.com/team/logo/p0857ky5-7.png", "backgroundUrl": "https://uploads.mixer.com/team/background/7k5tsbnx-7.jpg", "totalViewersCurrent": 0, "createdAt": "2016-04-21T03:22:10.000Z", "updatedAt": "2017-06-05T16:38:10.000Z" }
+        "example": {
+            "id": 7,
+            "ownerId": 696,
+            "token": "mixer",
+            "name": "Mixer Team",
+            "description": "<p>Mixer team streamers! </p>\n",
+            "logoUrl": "https://uploads.mixer.com/team/logo/p0857ky5-7.png",
+            "backgroundUrl": "https://uploads.mixer.com/team/background/7k5tsbnx-7.jpg",
+            "totalViewersCurrent": 0,
+            "createdAt": "2016-04-21T03:22:10.000Z",
+            "updatedAt": "2017-06-05T16:38:10.000Z"
+        }
     },
     "user:{id}:teamInvited": {
         "description": "Sent when a user is invited to a team.",
@@ -320,7 +649,33 @@
             "type": "Team",
             "description": "The team the user was invited to. This includes the team owner's user object as `owner`."
         },
-        "example": { "id": 7, "ownerId": 696, "token": "mixer", "name": "Mixer Team", "description": "<p>Mixer team streamers! </p>\n", "logoUrl": "https://uploads.mixer.com/team/logo/p0857ky5-7.png", "backgroundUrl": "https://uploads.mixer.com/team/background/7k5tsbnx-7.jpg", "totalViewersCurrent": 0, "createdAt": "2016-04-21T03:22:10.000Z", "updatedAt": "2017-06-05T16:38:10.000Z", "owner": { "level": 5, "social": {}, "id": 696, "username": "HypeBot", "verified": true, "experience": 72, "sparks": 1620, "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg", "bio": "", "primaryTeam": null, "createdAt": "2015-02-19T17:43:07.000Z", "updatedAt": "2017-05-25T16:26:14.000Z", "deletedAt": null } }
+        "example": {
+            "id": 7,
+            "ownerId": 696,
+            "token": "mixer",
+            "name": "Mixer Team",
+            "description": "<p>Mixer team streamers! </p>\n",
+            "logoUrl": "https://uploads.mixer.com/team/logo/p0857ky5-7.png",
+            "backgroundUrl": "https://uploads.mixer.com/team/background/7k5tsbnx-7.jpg",
+            "totalViewersCurrent": 0,
+            "createdAt": "2016-04-21T03:22:10.000Z",
+            "updatedAt": "2017-06-05T16:38:10.000Z",
+            "owner": {
+                "level": 5,
+                "social": {},
+                "id": 696,
+                "username": "HypeBot",
+                "verified": true,
+                "experience": 72,
+                "sparks": 1620,
+                "avatarUrl": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg",
+                "bio": "",
+                "primaryTeam": null,
+                "createdAt": "2015-02-19T17:43:07.000Z",
+                "updatedAt": "2017-05-25T16:26:14.000Z",
+                "deletedAt": null
+            }
+        }
     },
     "user:{id}:teamRemoved": {
         "description": "Sent when a user leaves a team or rejects its invite.",
@@ -328,7 +683,18 @@
             "type": "Team",
             "description": "The team the user left."
         },
-        "example": { "id": 7, "ownerId": 696, "token": "mixer", "name": "Mixer Team", "description": "<p>Mixer team streamers! </p>\n", "logoUrl": "https://uploads.mixer.com/team/logo/p0857ky5-7.png", "backgroundUrl": "https://uploads.mixer.com/team/background/7k5tsbnx-7.jpg", "totalViewersCurrent": 0, "createdAt": "2016-04-21T03:22:10.000Z", "updatedAt": "2017-06-05T16:38:10.000Z" }
+        "example": {
+            "id": 7,
+            "ownerId": 696,
+            "token": "mixer",
+            "name": "Mixer Team",
+            "description": "<p>Mixer team streamers! </p>\n",
+            "logoUrl": "https://uploads.mixer.com/team/logo/p0857ky5-7.png",
+            "backgroundUrl": "https://uploads.mixer.com/team/background/7k5tsbnx-7.jpg",
+            "totalViewersCurrent": 0,
+            "createdAt": "2016-04-21T03:22:10.000Z",
+            "updatedAt": "2017-06-05T16:38:10.000Z"
+        }
     },
     "user:{id}:update": {
         "description": "Sent when the user model is changed.",

--- a/src/reference/constellation/index.pug
+++ b/src/reference/constellation/index.pug
@@ -226,5 +226,5 @@ block reference
                                                 if typeof data.example === 'object'
                                                     +highlightStr('json', JSON.stringify(data.example, ' ', 2))
                                                 else
-                                                    =data.example
+                                                    = data.example
     include ../../snippets/help.pug

--- a/src/reference/constellation/index.pug
+++ b/src/reference/constellation/index.pug
@@ -209,5 +209,20 @@ block reference
                             small
                                 +typeNameString({ type: data.payload.type, required: true })
                             +simpleType('', data.payload, true)
+                        if data.example
+                            p
+                                a(href=`#example_${name.replace(/\W/g, '_')}`) See example
+                            .modal.fade(tabindex='0' id=`example_${name.replace(/\W/g, '_')}`)
+                                .modal-dialog.modal-lg
+                                    .modal-content
+                                        .modal-header
+                                            button.close(type='button' data-dismiss='modal' aria-hidden='true')!= '&times'
+                                            h4.modal-title
+                                                span.text-primary(style='font-weight:300') Example
+                                                | &nbsp;
+                                                span= name
+                                        .modal-body
+                                            code
+                                                +highlightStr('json', JSON.stringify(data.example, ' ', 2))
 
     include ../../snippets/help.pug

--- a/src/reference/constellation/index.pug
+++ b/src/reference/constellation/index.pug
@@ -204,21 +204,10 @@ block reference
                     td(style='white-space:nowrap;'): code= name
                     td
                         div!= marked(data.description)
-                        if !data.payload.type
-                            div
-                                span Payload:
-                                small &nbsp;
-                                    +typeNameString({ type: 'object', required: true })
-                            ul.rest-nested-properties
-                                for item, key in data.payload
-                                    li
-                                        +simpleTypeHeading(key, { type: item.type, required: true })
-                                        +simpleType(key, { type: item.type, description: item.description })
-                        else
-                            div
-                                span Payload:
-                                small &nbsp;
-                                    +typeNameString({ type: data.payload.type, required: true })
-                                +simpleType('Returns', { type: data.payload.type, description: data.payload.description })
+                        if data.payload
+                            strong Payload:&nbsp;
+                            small
+                                +typeNameString({ type: data.payload.type, required: true })
+                            +simpleType('', data.payload, true)
 
     include ../../snippets/help.pug

--- a/src/reference/constellation/index.pug
+++ b/src/reference/constellation/index.pug
@@ -211,20 +211,22 @@ block reference
                             +simpleType('', data.payload, true)
                         if data.example
                             p
-                                a(href=`#example_${name.replace(/\W/g, '_')}`) See example
-                            .modal.fade(tabindex='0' id=`example_${name.replace(/\W/g, '_')}`)
-                                .modal-dialog.modal-lg
-                                    .modal-content
-                                        .modal-header
-                                            button.close(type='button' data-dismiss='modal' aria-hidden='true')!= '&times'
-                                            h4.modal-title
-                                                span.text-primary(style='font-weight:300') Example
-                                                | &nbsp;
-                                                span= name
-                                        .modal-body
-                                            code
-                                                if typeof data.example === 'object'
-                                                    +highlightStr('json', JSON.stringify(data.example, ' ', 2))
-                                                else
-                                                    = data.example
+                                a(href=`#example_${name.replace(/\W/g, '_')}`) View example
+    for data, name in liveEvents
+        if data.example
+            .modal.fade(tabindex='0' id=`example_${name.replace(/\W/g, '_')}`)
+                .modal-dialog.modal-lg
+                    .modal-content
+                        .modal-header
+                            button.close(type='button' data-dismiss='modal' aria-hidden='true')!= '&times'
+                            h4.modal-title
+                                span.text-primary(style='font-weight:300') Example
+                                | &nbsp;
+                                span= name
+                        .modal-body
+                            code
+                                if typeof data.example === 'object'
+                                    +highlightStr('json', JSON.stringify(data.example, ' ', 2))
+                                else
+                                    = data.example
     include ../../snippets/help.pug

--- a/src/reference/constellation/index.pug
+++ b/src/reference/constellation/index.pug
@@ -1,4 +1,5 @@
 extends ../reference_layout.pug
+include ../../rest/type.pug
 
 block title
     | Constellation Reference | Mixer Developers
@@ -189,7 +190,7 @@ block reference
     h3#events_live live
     p.
         A live event looks like the following. Do note the socket event names are not liveloading events. Events you ask for over liveloading are always "live" events which contain the liveloading information. This separation is added so that other kinds of events can be distinguished from liveloading events.
-    +highlightStr('json','{"type": "event", "event": "live", "data": {"channel": "user:1:update", "payload": {"sparks": 10000}}')
+    +highlightStr('json','{"type": "event", "event": "live", "data": {"channel": "user:1:update", "payload": {"sparks": 10000}}}')
     h4#events_live_events Live Event Types
     p The following live events are available to #[a(href='#methods_livesubscribe') subscribe to].
     table.table
@@ -198,9 +199,26 @@ block reference
                 th Event
                 th Description
         tbody
-            for description, name in liveEvents
+            for data, name in liveEvents
                 tr
                     td(style='white-space:nowrap;'): code= name
-                    td!= marked(description)
+                    td
+                        div!= marked(data.description)
+                        if !data.payload.type
+                            div
+                                span Payload:
+                                small &nbsp;
+                                    +typeNameString({ type: 'object', required: true })
+                            ul.rest-nested-properties
+                                for item, key in data.payload
+                                    li
+                                        +simpleTypeHeading(key, { type: item.type, required: true })
+                                        +simpleType(key, { type: item.type, description: item.description })
+                        else
+                            div
+                                span Payload:
+                                small &nbsp;
+                                    +typeNameString({ type: data.payload.type, required: true })
+                                +simpleType('Returns', { type: data.payload.type, description: data.payload.description })
 
     include ../../snippets/help.pug

--- a/src/reference/constellation/index.pug
+++ b/src/reference/constellation/index.pug
@@ -223,6 +223,8 @@ block reference
                                                 span= name
                                         .modal-body
                                             code
-                                                +highlightStr('json', JSON.stringify(data.example, ' ', 2))
-
+                                                if typeof data.example === 'object'
+                                                    +highlightStr('json', JSON.stringify(data.example, ' ', 2))
+                                                else
+                                                    =data.example
     include ../../snippets/help.pug

--- a/src/rest/type.pug
+++ b/src/rest/type.pug
@@ -7,7 +7,7 @@ mixin type(key, type, skipRequired)
         if type.repeat
             span.help(title='List') []
 
-mixin typeNameString(type)
+mixin typeNameString(type, skipRequired)
     -
         var name = Array.isArray(type.type) ? type.type[0] : type.type;
         var isArray = true;
@@ -69,7 +69,7 @@ mixin typeNameString(type)
             | ]
     if isArray
         | &gt;
-    if !type.default && !type.required
+    if !type.default && !type.required && !skipRequired
         span.help(title='Optional') ?
     if name === 'array' && type.items
         - var parentType = type.items.type && type.items.type[0];
@@ -85,11 +85,11 @@ mixin typeExample(type)
     if typeof type.example === 'object'
         +highlightStr("json", JSON.stringify(type.example,null, 3))
 
-mixin simpleTypeHeading(key, type)
+mixin simpleTypeHeading(key, type, skipRequired)
     span.text-monospace= restUtil.prettifyPropertyName(type.displayName || key)
     = ': '
     small &nbsp;
-        +typeNameString(type)
+        +typeNameString(type, skipRequired)
 
 mixin describeSimpleType(key, type)
     if type.description
@@ -128,7 +128,7 @@ mixin simpleType(key, type, skipRequired)
         ul.rest-nested-properties
             for property, propertyName in type.properties
                 li
-                    +simpleTypeHeading(propertyName, property)
+                    +simpleTypeHeading(propertyName, property, skipRequired)
                     +simpleType(propertyName, property)
 
     if rootType === 'array' && type.items
@@ -144,7 +144,7 @@ mixin simpleType(key, type, skipRequired)
                     ul.rest-nested-properties
                         for property, propertyName in type.items.properties
                             li
-                                +simpleTypeHeading(propertyName, property)
+                                +simpleTypeHeading(propertyName, property, skipRequired)
                                 +simpleType(propertyName, property)
             else
                 li Item type:

--- a/src/rest/type.pug
+++ b/src/rest/type.pug
@@ -56,7 +56,7 @@ mixin typeNameString(type)
             span.help(title='Min value')= type.minimum
             | &leq;
         if rest.types[name]
-            a(href=`#${name}`)= name
+            a(href=`/rest.html#${name}`)= name
         else
             = name
         if type.default


### PR DESCRIPTION
Adds info on each Constellation event's payload/fields, as well as full examples for each. Also adds `costream:{id}:update`.

![screenshot](https://smallimage.in/figql.png)