### PR TITLE
feat(doc-gen): allow endpoints to be hidden until embargo dates pass

### DIFF
--- a/build/docs.js
+++ b/build/docs.js
@@ -16,6 +16,8 @@ const childProcess = Bluebird.promisifyAll(require('child_process'));
 // unneeded.
 const ramlParser = () => require('raml-1-parser');
 
+const now = Date.now();
+
 /**
  * Ensures that the repo cloneable at the provided address is downloaded
  * and up-to-date.
@@ -192,7 +194,7 @@ function filterRaml (node) {
 
         const annotations = subNode.annotations;
         const embargo = _.get(annotations, 'embargo.structuredValue');
-        if (embargo && new Date(embargo).getTime() > Date.now()) {
+        if (embargo && new Date(embargo).getTime() > now) {
             return;
         }
         if (annotations && annotations.internal) {

--- a/build/docs.js
+++ b/build/docs.js
@@ -189,7 +189,13 @@ function filterRaml (node) {
             add(index, subNode);
             return;
         }
-        if (subNode.annotations && subNode.annotations.internal) {
+
+        const annotations = subNode.annotations;
+        const embargo = _.get(annotations, 'embargo.structuredValue');
+        if (embargo && new Date(embargo).getTime() > Date.now()) {
+            return;
+        }
+        if (annotations && annotations.internal) {
             return;
         }
         const newSubNode = filterRaml(subNode);


### PR DESCRIPTION
Quick idea I had. Lets us hit the "deploy" button on the dev site to have endpoints magically appear when they're released instead of needing to branch, edit, PR, and review removing `(internal)` tags on the backend, then deploying the dev site. E.g. with costreams they didn't actually make it onto the dev site for a couple weeks after release.