### PR TITLE
fix(unions): Make unions render correctly when arrays are involved

### DIFF
--- a/build/libraries.json
+++ b/build/libraries.json
@@ -24,12 +24,6 @@
         "official": true
     },
     {
-        "language": "java",
-        "name": "Mixer/beam-interactive-java",
-        "alias": "interactive-java",
-        "official": true
-    },
-    {
         "language": "js",
         "name": "Mixer/interactive-node",
         "alias": "interactive-node",

--- a/build/libraries.json
+++ b/build/libraries.json
@@ -36,9 +36,9 @@
         "official": true
     },
     {
-        "language": "python",
-        "name": "Mixer/interactive-python",
-        "alias": "interactive-python",
+        "language": "java",
+        "name": "Mixer/interactive-java",
+        "alias": "interactive-java",
         "official": true
     }
 ]

--- a/src/rest/type.pug
+++ b/src/rest/type.pug
@@ -156,5 +156,3 @@ mixin simpleType(key, type, skipRequired)
                 li Item type:
                     = ' '
                     +typeNameString(type.items)
-    if rootType.length > 0
-

--- a/src/rest/type.pug
+++ b/src/rest/type.pug
@@ -13,7 +13,14 @@ mixin typeNameString(type, skipRequired)
         var isArray = true;
         var union = null;
 
-        if (name.slice(-2) === '[]') {
+        if (/ \| /.test(name)) {
+            union = name.split(' | ');
+            if (union) {
+                isArray = false;
+            }
+        }
+
+        if (name.slice(-2) === '[]' && !union) {
             name = name.slice(0, -2);
         } else if (type.items) {
             if (type.items.type.length > 0) {
@@ -23,10 +30,6 @@ mixin typeNameString(type, skipRequired)
             }
         } else {
             isArray = false;
-        }
-
-        if (/^\(.+\|.+\)$/.test(name)) {
-            union = name.slice(1, -1).split(/\W*\|\W*/g);
         }
 
     if type.default
@@ -42,15 +45,18 @@ mixin typeNameString(type, skipRequired)
         if type.default
             span.help(title='Default Value')= `=${type.default}`
     else if union
-        | (
         for nested, i in union
             if i > 0
                 = ' ∪ '
-            if rest.types[nested]
-                a(href=`#${nested}`)= nested
+            -
+                var nestedType = nested;
+                if (nestedType.slice(-2) === '[]') {
+                    nestedType = nested.slice(0,-2);
+                }
+            if rest.types[nestedType]
+                a(href=`#${nestedType}`)= nested
             else
                 = nested
-        | )
     else
         if type.minimum
             span.help(title='Min value')= type.minimum
@@ -150,3 +156,5 @@ mixin simpleType(key, type, skipRequired)
                 li Item type:
                     = ' '
                     +typeNameString(type.items)
+    if rootType.length > 0
+

--- a/src/rest/type.pug
+++ b/src/rest/type.pug
@@ -76,7 +76,7 @@ mixin printType(type)
             typeLink = type.slice(0,-2);
         }
     if rest.types[typeLink]
-        a(href=`#${typeLink}`)= type
+        a(href=`/rest.html#${typeLink}`)= type
     else
         = type
 mixin typeExample(type)

--- a/src/rest/type.pug
+++ b/src/rest/type.pug
@@ -15,9 +15,7 @@ mixin typeNameString(type, skipRequired)
 
         if (/ \| /.test(name)) {
             union = name.split(' | ');
-            if (union) {
-                isArray = false;
-            }
+            isArray = false;
         }
 
         if (name.slice(-2) === '[]' && !union) {
@@ -37,10 +35,7 @@ mixin typeNameString(type, skipRequired)
     if isArray
         | Array&lt;
     if type.enum
-        if rest.types[name]
-            a(href=`#${name}`)= name
-        else
-            = name
+        +printType(name)
         != ` (${type.enum.map(val => `<code>${val}</code>`).join()})`
         if type.default
             span.help(title='Default Value')= `=${type.default}`
@@ -48,23 +43,12 @@ mixin typeNameString(type, skipRequired)
         for nested, i in union
             if i > 0
                 = ' ∪ '
-            -
-                var nestedType = nested;
-                if (nestedType.slice(-2) === '[]') {
-                    nestedType = nested.slice(0,-2);
-                }
-            if rest.types[nestedType]
-                a(href=`#${nestedType}`)= nested
-            else
-                = nested
+            +printType(nested)
     else
         if type.minimum
             span.help(title='Min value')= type.minimum
             | &leq;
-        if rest.types[name]
-            a(href=`/rest.html#${name}`)= name
-        else
-            = name
+        +printType(name)
         if type.default
             | =
             span.help(title='Default Value')= type.default
@@ -83,8 +67,18 @@ mixin typeNameString(type, skipRequired)
             = ' '
             small extends
                 = ' '
-                a(href=`#${parentType}`)= parentType
+                +printType(parentType)
         | :
+mixin printType(type)
+    -
+        var typeLink = type;
+        if (typeLink.slice(-2) === '[]') {
+            typeLink = type.slice(0,-2);
+        }
+    if rest.types[typeLink]
+        a(href=`#${typeLink}`)= type
+    else
+        = type
 mixin typeExample(type)
     if typeof type.example === 'string'
         pre= type.example


### PR DESCRIPTION
Here we update the union handling to be a bit better. A lot of this was a bit of a mess.The array handling was clobbering unions.

![](https://i.probableprime.co.uk/fOBeSNH.png)
![](https://i.probableprime.co.uk/Lhq2b2S.png)

In addition unions in raml are without "()" [spec](https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md/#union-type)

The raml updates to make this render correctly are in: https://github.com/mixer/backend/pull/1464

