### PR TITLE
fix(tutorial): add chat:bypass_slowchat scope to token link

### DIFF
--- a/src/tutorials/chatbot.pug
+++ b/src/tutorials/chatbot.pug
@@ -2,7 +2,7 @@ extends ./tutorial_layout.pug
 include ../mixins.pug
 
 block append scripts
-    +oauthLinks('chat:connect chat:chat')
+    +oauthLinks('chat:connect chat:chat chat:bypass_slowchat')
 
 block title
     | Chatbot Tutorial | Mixer Developers


### PR DESCRIPTION
The `Click here to get your token` link in all the tutorials automatically gives you an access token for making a simple ping/pong bot. However, a few have had trouble with this because the bot runs under the same account as the developer. The chat server sees "!ping" then "PONG!" from the same user, and then "PONG!" is blocked due to slowchat.

This adds `chat:bypass_slowchat` to the access token link to fix this problem, for those who want to get started making a chat bot.

Bug 3903