### PR TITLE
fix(build): make beam-common an optional dep

### DIFF
--- a/build/misc.js
+++ b/build/misc.js
@@ -38,6 +38,21 @@ function wrappedRequire (filePath) {
 }
 
 /**
+ * Returns the array of permissions to be shown on the OAuth section of the docs.
+ * @return {Object[]}
+ */
+function getPermissions () {
+    try {
+        return require('@mcph/beam-common').permissions;
+    } catch (err) {
+        if (err.code === 'MODULE_NOT_FOUND') {
+            return [];
+        }
+        throw err;
+    }
+}
+
+/**
  * Generates locals required for templating.
  * `permissions` is used for the REST API docs, they are displayed in a table.
  * @return {Object}
@@ -50,7 +65,7 @@ function getLocals () {
         },
     });
 
-    const permissions = require('@mcph/beam-common').permissions;
+    const permissions = getPermissions();
     const permissionKeys = Object.keys(permissions).sort();
     const out = {
         _,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "homepage": "https://github.com/mixer/developers#readme",
   "devDependencies": {
-    "@mcph/beam-common": "^5.0.5",
     "bluebird": "^3.4.1",
     "bootstrap": "^3.3.7",
     "config": "^1.21.0",
@@ -57,5 +56,8 @@
     "pug-lint": "^2.2.2",
     "raml-1-parser": "^0.2.33",
     "sticky-kit": "^1.1.3"
+  },
+  "optionalDependencies": {
+    "@mcph/beam-common": "^5.0.6"
   }
 }


### PR DESCRIPTION
The OAuth Scopes table won't generate if beam-common isn't available, so third-parties can still build the site.