### PR TITLE
fix(constellation): remove status event

### DIFF
--- a/src/reference/constellation/events.json
+++ b/src/reference/constellation/events.json
@@ -183,9 +183,6 @@
             }
         }
     },
-    "channel:{id}:status": {
-        "description": "Subscribes to the online status of a channel. You'll get events sent down named `chat:{id}:StartStreaming` and `chat:{id}:StopStreaming`."
-    },
     "channel:{id}:subscribed": {
         "description": "Sent when a user subscribes to the channel.",
         "payload": {


### PR DESCRIPTION
Removes the weird `channel:{id}:status` (`chat:{id}:StartStreaming`) event from the constellation reference, in favour of just listening to `channel:{id}:update`.