### PR TITLE
fix: replace forums links

### DIFF
--- a/src/index.pug
+++ b/src/index.pug
@@ -98,10 +98,10 @@ block content
                     .slide-features-img
                         img(src='/img/icon/bubble-chat-typing-3.svg' alt='Chat with us on Gitter' target='_blank')
                     p Chat with us #[br] on Gitter
-                .col-md-3.col-sm-6.col-xs-12: a(href='https://forums.mixer.com/category/10/developer-discussion' target='_blank')
+                .col-md-3.col-sm-6.col-xs-12: a(href='https://discord.gg/mixer' target='_blank')
                     .slide-features-img
                         img(src='/img/icon/chat-double-bubble-1.svg' alt='Go to our Dev Forums' target='_blank')
-                    p Check out our #[br] Developer Forums
+                    p Talk to other developers #[br] on Discord
                 .col-md-3.col-sm-6.col-xs-12: a(href='https://twitter.com/WatchMixer' target='_blank')
                     .slide-features-img
                         img(src='/img/icon/logo-twitter-bird.svg' alt='Find us on Twitter' target='_blank')

--- a/src/layout.pug
+++ b/src/layout.pug
@@ -82,9 +82,9 @@ html
                         h3 Network
                         ul
                             li: a(href='https://mixer.com' target='_blank') mixer.com
-                            li: a(href='https://forums.mixer.com/' target='_blank') Mixer Forums
                             li: a(href='https://blog.mixer.com/' target='_blank') Blog
                             li: a(href='https://feedback.mixer.com/forums/382521-lazers-and-shiny-things/category/174978-developer-ecosystem' target='_blank') Feedback
+                            li: a(href='https://discord.gg/mixer' target='_blank') Discord
 
                     .col-lg-2.col-md-3.col-xs-6
                         h3 Legal


### PR DESCRIPTION
Replaces forums.mixer.com links with links to our Discord server, for now