### PR TITLE
feat(chat): add documentation for catbot

### DIFF
--- a/src/reference/chat/data.json
+++ b/src/reference/chat/data.json
@@ -648,13 +648,6 @@
               "meta": {
                 "censored": true
               }
-            },
-            "recipientFilter": {
-              "roles": [
-                "Mod",
-                "Owner",
-                "Staff"
-              ]
             }
           }
         }

--- a/src/reference/chat/data.json
+++ b/src/reference/chat/data.json
@@ -618,6 +618,45 @@
               "meta": {}
             }
           }
+        },
+        {
+          "title": "Censored Message",
+          "description": "A channel owner can configure their channel's <a href=\"https://aka.ms/mixercatbot\" target=\"_blank\">Catbot auto moderation</a> settings so that unwanted chat messages are automatically dropped. If a message is sent and that message violates this filter, only channel moderators and the channel owner will receive that message, with the `censored` meta property set as shown below. Other users shall not receive the chat message.",
+          "data": {
+            "channel": 12345,
+            "id": "c46148d0-3a30-11e6-b368-2953589298fa",
+            "user_name": "username",
+            "user_id": 12345,
+            "user_roles": [
+              "User"
+            ],
+            "user_level": 5,
+            "user_avatar": "https://uploads.mixer.com/avatar/ed47s4h5-696.jpg",
+            "message": {
+              "message": [
+                {
+                  "type": "text",
+                  "data": "A bad message.",
+                  "text": "A bad message."
+                },
+                {
+                  "type": "text",
+                  "data": "( Removed by CatBot )",
+                  "text": "( Removed by CatBot )"
+                }
+              ],
+              "meta": {
+                "censored": true
+              }
+            },
+            "recipientFilter": {
+              "roles": [
+                "Mod",
+                "Owner",
+                "Staff"
+              ]
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
If a chatbot is a mod, they might want to properly handle/ignore Catbot-filtered messages. Added an example to the chat reference to explain this.