### PR TITLE
Fix rebuild for outside developers

### DIFF
--- a/src/rest/type.pug
+++ b/src/rest/type.pug
@@ -75,7 +75,7 @@ mixin printType(type)
         if (typeLink.slice(-2) === '[]') {
             typeLink = type.slice(0,-2);
         }
-    if rest.types[typeLink]
+    if rest && rest.types[typeLink]
         a(href=`/rest.html#${typeLink}`)= type
     else
         = type


### PR DESCRIPTION
When trying to run `gulp recompile` the following error happened:
```
PS D:\developers> npm run rebuild

> beam-developers@2.0.0 rebuild D:\developers
> gulp recompile

[22:20:20] Using gulpfile D:\developers\gulpfile.js
[22:20:20] Starting 'html-quick'...
Cannot find common module. OAuth scope table will be omitted.
[22:20:20] Starting 'js'...
[22:20:20] Starting 'iconfont'...
[22:20:20] Starting 'images'...
[22:20:21] gulp-svgicons2svgfont: The fontHeight should larger than 1000 or it will be converted into the wrong shape. Using the "normalize" and "fontHeight" options can solve the problem.
[22:20:21] gulp-svgicons2svgfont: Font created
[22:20:21] Finished 'js' after 629 ms
[22:20:21] Finished 'iconfont' after 884 ms
[22:20:21] Starting 'css'...
[22:20:22] Finished 'css' after 1.06 s

events.js:183
      throw er; // Unhandled 'error' event
      ^
TypeError: D:\developers\src\rest\type.pug:78
    76|             typeLink = type.slice(0,-2);
    77|         }
  > 78|     if rest.types[typeLink]
    79|         a(href=`/rest.html#${typeLink}`)= type
    80|     else
    81|         = type

Cannot read property 'types' of null
    at Object.pug_interp [as printType] (eval at wrap (D:\developers\node_modules\pug-runtime\wrap.js:6:10), <anonymous>:1218:10)
    at Object.pug_interp [as typeNameString] (eval at wrap (D:\developers\node_modules\pug-runtime\wrap.js:6:10), <anonymous>:1147:24)
    at Object.eval (eval at wrap (D:\developers\node_modules\pug-runtime\wrap.js:6:10), <anonymous>:1711:29)
    at Object.pug_interp [as liveEventsTable] (eval at wrap (D:\developers\node_modules\pug-runtime\wrap.js:6:10), <anonymous>:1738:4)
```

Just added a check to stop the error.