### PR TITLE
fix(next-preact): fix some tutorial code issues

### DIFF
--- a/src/reference/interactive_next/controls/scene-01.jsx
+++ b/src/reference/interactive_next/controls/scene-01.jsx
@@ -3,12 +3,11 @@ import { h } from 'preact';
 
 import { PreactScene, Translate } from './alchemy/preact';
 
-@Mixer.Scene({ name: 'leaderboard' })
-export class LeaderboardScene extends PreactScene {
+@Mixer.Scene({ id: 'leaderboard' })
+export class LeaderboardScene extends PreactScene<{}> {
     render() {
         return <div>
             <h1><Translate string="And the winners are..." /></h1>
-            {super.render()} // calls the PreactScene's render method
         </div>;
     }
 }


### PR DESCRIPTION
Mixer.Scene uses id, not name.
PreactScene requires at least one type argument, added empty object to replicate default scene
super.render doesn't work because PreactScene doesn't implement it and it's ancestor is abstract.